### PR TITLE
Added: configuration settings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,10 @@ gem 'bootsnap', '>= 1.1.0', require: false
 # https://github.com/doorkeeper-gem/doorkeeper
 gem 'doorkeeper', '>= 5.0.1'
 
+# Settings is a plugin that makes managing a table of global key, value pairs easy.
+# https://github.com/huacnlee/rails-settings-cached
+gem 'rails-settings-cached'
+
 # Rack Middleware for handling Cross-Origin Resource Sharing (CORS), which makes cross-origin AJAX possible.
 # https://github.com/cyu/rack-cors
 gem 'rack-cors', require: 'rack/cors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,6 +158,8 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
+    rails-settings-cached (0.7.2)
+      rails (>= 4.2.0)
     railties (5.2.2)
       actionpack (= 5.2.2)
       activesupport (= 5.2.2)
@@ -268,6 +270,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rack-cors
   rails (~> 5.2.2)
+  rails-settings-cached
   rollbar
   rspec-parameterized
   rspec-rails

--- a/app/models/application_settings.rb
+++ b/app/models/application_settings.rb
@@ -1,0 +1,10 @@
+# ApplicationSettings
+#
+#   Used to store application-wide settings(RailsSettings Model)
+#
+# NOTE : When config/elplano.yml has changed, you need change this prefix to v2, v3 ... to expires caches
+#        cache_prefix { "v1" }
+#
+class ApplicationSettings < RailsSettings::Base
+  source Rails.root.join('config/elplano.yml')
+end

--- a/config/elplano.yml
+++ b/config/elplano.yml
@@ -1,0 +1,16 @@
+# config/elplano.yml for rails-settings-cached
+defaults: &defaults
+  # Built in monitoring settings
+  monitoring:
+    # IP whitelist to access monitoring endpoints
+    ip_whitelist:
+      - 127.0.0.0/8
+
+development:
+  <<: *defaults
+
+test:
+  <<: *defaults
+
+production:
+  <<: *defaults

--- a/db/migrate/20190129184540_create_settings.rb
+++ b/db/migrate/20190129184540_create_settings.rb
@@ -1,0 +1,17 @@
+class CreateSettings < ActiveRecord::Migration[5.2]
+  def self.up
+    create_table :settings do |t|
+      t.string  :var,        null: false
+      t.text    :value,      null: true
+      t.integer :thing_id,   null: true
+      t.string  :thing_type, null: true, limit: 30
+      t.timestamps
+    end
+
+    add_index :settings, %i(thing_type thing_id var), unique: true
+  end
+
+  def self.down
+    drop_table :settings
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_27_150426) do
+ActiveRecord::Schema.define(version: 2019_01_29_184540) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,6 +67,16 @@ ActiveRecord::Schema.define(version: 2019_01_27_150426) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
+  end
+
+  create_table "settings", force: :cascade do |t|
+    t.string "var", null: false
+    t.text "value"
+    t.integer "thing_id"
+    t.string "thing_type", limit: 30
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["thing_type", "thing_id", "var"], name: "index_settings_on_thing_type_and_thing_id_and_var", unique: true
   end
 
   create_table "students", force: :cascade do |t|

--- a/lib/elplano.rb
+++ b/lib/elplano.rb
@@ -13,6 +13,10 @@ module Elplano
     Pathname.new(File.expand_path('..', __dir__))
   end
 
+  def self.config
+    ApplicationSettings
+  end
+
   def self.migrations_hash
     @_migrations_hash ||= Digest::MD5.hexdigest(ActiveRecord::Migrator.get_all_versions.to_s)
   end

--- a/lib/middleware/health_check.rb
+++ b/lib/middleware/health_check.rb
@@ -40,7 +40,11 @@ module Middleware
     end
 
     def ip_whitelist
-      @ip_whitelist ||= ['127.0.0.0/8'].map(&IPAddr.method(:new))
+      @ip_whitelist ||= monitoring['ip_whitelist'].map(&IPAddr.method(:new))
+    end
+
+    def monitoring
+      Elplano.config.monitoring
     end
   end
 end

--- a/spec/lib/elplano_spec.rb
+++ b/spec/lib/elplano_spec.rb
@@ -40,4 +40,8 @@ describe Elplano do
       it { expect(described_class.revision).to eq('Unknown') }
     end
   end
+
+  describe '.config' do
+    it { expect(described_class.config).to be ApplicationSettings }
+  end
 end


### PR DESCRIPTION
Added the ability to add/save application settings. 
`Elplano.config` is used as an entry point for settings access.

[Rails Settings Cached](https://github.com/huacnlee/rails-settings-cached) is used to handle settings storage. 