### PR TITLE
Added: dockerization stage 3: image publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,15 @@ jobs:
         run:
           - "rake db:migrate"
     - stage: docker
-      before_install:
-        - docker-compose -f docker-compose.test.yml build
-        - docker-compose -f docker-compose.test.yml up -d && docker ps
+      install: skip
+      before_script:
+        - docker --version
+        - docker-compose --version
       script:
-        - docker-compose -f docker-compose.test.yml exec app bin/rake db:create db:migrate
-        - docker-compose -f docker-compose.test.yml exec app bin/bundle exec rspec
+        - sh scripts/test-image.sh
+      deploy:
+        - provider: script
+          script: scripts/build-image.sh
+          on:
+            branches:
+              - develop

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+set -e
+set -v
+
+docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" --password-stdin
+
+docker pull ${DOCKER_REPOSITORY}:last_successful_build || true
+docker pull ${DOCKER_REPOSITORY}:${TRAVIS_COMMIT} || true
+
+docker build -t ${DOCKER_REPOSITORY}:${TRAVIS_COMMIT} --pull=true .
+
+docker push ${DOCKER_REPOSITORY}:${TRAVIS_COMMIT}
+
+docker tag -f ${DOCKER_REPOSITORY}:${TRAVIS_COMMIT} ${DOCKER_REPOSITORY}:last_successful_build
+
+docker push ${DOCKER_REPOSITORY}:last_successful_build
+

--- a/scripts/test-image.sh
+++ b/scripts/test-image.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+set -e
+set -v
+
+COMPOSE_FILE=docker-compose.test.yml
+
+docker-compose -f $COMPOSE_FILE build --pull
+docker-compose -f $COMPOSE_FILE up -d && docker ps
+docker-compose -f $COMPOSE_FILE exec app bin/rake db:create db:migrate
+docker-compose -f $COMPOSE_FILE exec app bin/bundle exec rspec


### PR DESCRIPTION
At the third stage of the dockerization, the image build and the
subsequent publication to the docker hub was added

Minor changes in travis.yml docker section

Related files:

- `scripts/test-image.sh` - a script for image build and test with use  of docker-compose
- `scripts/build-image.sh` - a script for image build and publish to Docker Hub