### PR TITLE
Closes #41 : groups stuff

### DIFF
--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    # Api::V1::GroupsController
+    #
+    #   Used to control current user's group.
+    #
+    #   Regular group member can:
+    #
+    #     - obtain information about his group.
+    #
+    #   President can:
+    #
+    #     - obtain information about group.
+    #     - update information about group.
+    #     - delete information about group.
+    #
+    #   User with no group can:
+    #
+    #     - create a new group and become a group president.
+    #
+    class GroupsController < ApplicationController
+      set_default_serializer GroupSerializer
+
+      before_action :authorize_edit, only: %i[update destroy]
+      before_action :authorize_create, only: :create
+
+      # GET : api/v1/group
+      #
+      # Get detailed information about current user's group
+      #
+      def show
+        render_json student_group, status: :ok
+      end
+
+      # POST : api/v1/group
+      #
+      # Creates new group
+      #
+      def create
+        group = Groups::Creator.new.execute(current_student, group_params)
+
+        render_json group, status: :created
+      end
+
+      # PATCH/PUT : api/v1/group
+      #
+      # Updates/renew information about current user's group
+      #
+      def update
+        supervised_group.update!(group_params)
+
+        render_json supervised_group.reload, status: :ok
+      end
+
+      # DELETE : api/v1/group
+      #
+      # Deletes current user's supervised group
+      #
+      def destroy
+        supervised_group.destroy!
+
+        head :no_content
+      end
+
+      private
+
+      def authorize_edit
+        return if current_student.group_owner?
+
+        raise Errors::AuthError, 'Edit not allowed'
+      end
+
+      def authorize_create
+        return unless current_student.any_group?
+
+        raise Errors::AuthError, 'Create not allowed'
+      end
+
+      def student_group
+        @student_group || current_student.group
+      end
+
+      def supervised_group
+        @supervised_group ||= current_student.supervised_group
+      end
+
+      def group_params
+        restify_param(:group)
+          .require(:group)
+          .permit(:title, :number)
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -39,12 +39,12 @@ module ExceptionHandler
       render_errors(
         [
           {
-            status: 401,
+            status: 403,
             detail: e.message,
             source: { pointer: 'authorization header' }
           }
         ],
-        :unauthorized
+        :forbidden
       )
     end
 

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -25,4 +25,12 @@ class Student < ApplicationRecord
   validates :phone,     length: { maximum: 50 }
 
   scope :presidents, -> { where(president: true) }
+
+  def any_group?
+    !supervised_group.nil? || !group.nil?
+  end
+
+  def group_owner?
+    supervised_group&.president_id == id
+  end
 end

--- a/app/services/groups/creator.rb
+++ b/app/services/groups/creator.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Groups
+  # Groups::Creator
+  #
+  #   Used to create new students group.
+  #
+  #   NOTE : owner automatically become a group member and group president.
+  #
+  class Creator
+
+    # @param [Student] owner Group owner(group president).
+    #   A Person, who can administer the group.
+    #
+    # @param [Hash] params Parameters required for group creation
+    #
+    # @option params [String] :number - Special group identity
+    # @option params [String] :title  - Human readable group identity
+    #
+    # @return [Group]
+    #
+    def execute(owner, params)
+      validate_owner!(owner)
+
+      ActiveRecord::Base.transaction do
+        owner.update!(president: true)
+
+        Group.create!(params) do |g|
+          g.president = owner
+          g.students << owner
+        end
+      end
+    end
+
+    private
+
+    def validate_owner!(owner)
+      return unless owner.president? || owner.any_group?
+
+      raise ActiveRecord::RecordInvalid.new(owner), 'student already has a group!'
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,8 @@ Rails.application.routes.draw do
 
   namespace :api, defaults: { format: 'json' } do
     namespace :v1 do
+      resource :group, except: %i[new edit]
+
       resource :me, only: :show, controller: :users
 
       scope :me do

--- a/documentation/api/events/create_:_creates_new_event.json
+++ b/documentation/api/events/create_:_creates_new_event.json
@@ -66,11 +66,11 @@
     {
       "request_method": "POST",
       "request_path": "api/v1/me/events",
-      "request_body": "{\"data\":{\"type\":\"event\",\"attributes\":{\"title\":\"Quaerat et in.\",\"description\":\"Officiis totam et. Minus distinctio qui. Sit iste voluptatem. Tempora modi illum. Perspiciatis voluptate eum.\",\"status\":\"cancelled\",\"start_at\":\"2019-02-09\",\"end_at\":\"2019-02-11\",\"timezone\":\"Etc/GMT+12\",\"recurrence\":[\"EXDATE;VALUE=DATE:20150610\",\"RDATE;VALUE=DATE:20150609,20150611\",\"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"]}}}",
+      "request_body": "{\"data\":{\"type\":\"event\",\"attributes\":{\"title\":\"Possimus atque sequi.\",\"description\":\"Odit rerum qui. Et ut nobis. Minima in tenetur. Iusto nisi excepturi. Ullam et officiis.\",\"status\":\"cancelled\",\"start_at\":\"2019-02-13\",\"end_at\":\"2019-02-15\",\"timezone\":\"Etc/GMT+12\",\"recurrence\":[\"EXDATE;VALUE=DATE:20150610\",\"RDATE;VALUE=DATE:20150609,20150611\",\"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"]}}}",
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 561a8ae31a3fbdd9f6867f549fa314bc127b5e52ffed912db2b03a2acce54e38",
+        "Authorization": "Bearer f388f4aff0aff60371b2334cb55cb29d0c5fd7937ad49e980091aa0341143077",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -79,7 +79,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 201,
       "response_status_text": "Created",
-      "response_body": "{\n  \"data\": {\n    \"id\": \"5\",\n    \"type\": \"event\",\n    \"attributes\": {\n      \"title\": \"Quaerat et in.\",\n      \"description\": \"Officiis totam et. Minus distinctio qui. Sit iste voluptatem. Tempora modi illum. Perspiciatis voluptate eum.\",\n      \"status\": \"cancelled\",\n      \"recurrence\": [\n        \"EXDATE;VALUE=DATE:20150610\",\n        \"RDATE;VALUE=DATE:20150609,20150611\",\n        \"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"\n      ],\n      \"start_at\": \"2019-02-09T00:00:00.000Z\",\n      \"end_at\": \"2019-02-11T00:00:00.000Z\",\n      \"timezone\": \"Etc/GMT+12\",\n      \"created_at\": \"2019-02-10T16:03:16.063Z\",\n      \"updated_at\": \"2019-02-10T16:03:16.063Z\"\n    },\n    \"relationships\": {\n      \"creator\": {\n        \"data\": {\n          \"id\": \"12\",\n          \"type\": \"creator\"\n        }\n      }\n    }\n  }\n}",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"5\",\n    \"type\": \"event\",\n    \"attributes\": {\n      \"title\": \"Possimus atque sequi.\",\n      \"description\": \"Odit rerum qui. Et ut nobis. Minima in tenetur. Iusto nisi excepturi. Ullam et officiis.\",\n      \"status\": \"cancelled\",\n      \"recurrence\": [\n        \"EXDATE;VALUE=DATE:20150610\",\n        \"RDATE;VALUE=DATE:20150609,20150611\",\n        \"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"\n      ],\n      \"start_at\": \"2019-02-13T00:00:00.000Z\",\n      \"end_at\": \"2019-02-15T00:00:00.000Z\",\n      \"timezone\": \"Etc/GMT+12\",\n      \"created_at\": \"2019-02-14T11:53:45.105Z\",\n      \"updated_at\": \"2019-02-14T11:53:45.105Z\"\n    },\n    \"relationships\": {\n      \"creator\": {\n        \"data\": {\n          \"id\": \"12\",\n          \"type\": \"creator\"\n        }\n      }\n    }\n  }\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -88,14 +88,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/vnd.api+json; charset=utf-8",
-        "ETag": "W/\"a42c9ee7d0caee4006711322f4d4948d\"",
-        "X-Request-Id": "b6d75ccb-e889-4dc2-91e5-e2fcdac04afe",
-        "X-Runtime": "0.008713",
+        "ETag": "W/\"f02eba69ace7aed4b2377155da89cab8\"",
+        "X-Request-Id": "b9fdb8f3-094c-4a8d-8a85-609f59d4d6d9",
+        "X-Runtime": "0.013569",
         "Vary": "Origin",
-        "Content-Length": "591"
+        "Content-Length": "577"
       },
       "response_content_type": "application/vnd.api+json; charset=utf-8",
-      "curl": "curl \"http://localhost:3000api/v1/me/events\" -d '{\"data\":{\"type\":\"event\",\"attributes\":{\"title\":\"Quaerat et in.\",\"description\":\"Officiis totam et. Minus distinctio qui. Sit iste voluptatem. Tempora modi illum. Perspiciatis voluptate eum.\",\"status\":\"cancelled\",\"start_at\":\"2019-02-09\",\"end_at\":\"2019-02-11\",\"timezone\":\"Etc/GMT+12\",\"recurrence\":[\"EXDATE;VALUE=DATE:20150610\",\"RDATE;VALUE=DATE:20150609,20150611\",\"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"]}}}' -X POST \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 561a8ae31a3fbdd9f6867f549fa314bc127b5e52ffed912db2b03a2acce54e38\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000api/v1/me/events\" -d '{\"data\":{\"type\":\"event\",\"attributes\":{\"title\":\"Possimus atque sequi.\",\"description\":\"Odit rerum qui. Et ut nobis. Minima in tenetur. Iusto nisi excepturi. Ullam et officiis.\",\"status\":\"cancelled\",\"start_at\":\"2019-02-13\",\"end_at\":\"2019-02-15\",\"timezone\":\"Etc/GMT+12\",\"recurrence\":[\"EXDATE;VALUE=DATE:20150610\",\"RDATE;VALUE=DATE:20150609,20150611\",\"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"]}}}' -X POST \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer f388f4aff0aff60371b2334cb55cb29d0c5fd7937ad49e980091aa0341143077\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/documentation/api/events/create_:_returns_400_status_code.json
+++ b/documentation/api/events/create_:_returns_400_status_code.json
@@ -19,7 +19,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 873b2c9428d30c3668cd5b11b78df44488476a9392ab6f706a113d0afe5953eb",
+        "Authorization": "Bearer e011eb6d6b2829b8ebf14fdf1c5eb7c9e626e468eb615ba4c76da736a1b56c5e",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -37,13 +37,13 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/vnd.api+json; charset=utf-8",
-        "X-Request-Id": "904dfdda-3c62-4d9f-b20b-6ac213c89212",
-        "X-Runtime": "0.006057",
+        "X-Request-Id": "2ca4c745-7312-4e45-9b44-b0e75a1182a3",
+        "X-Runtime": "0.006070",
         "Vary": "Origin",
         "Content-Length": "239"
       },
       "response_content_type": "application/vnd.api+json; charset=utf-8",
-      "curl": "curl \"http://localhost:3000api/v1/me/events\" -d '' -X POST \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 873b2c9428d30c3668cd5b11b78df44488476a9392ab6f706a113d0afe5953eb\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000api/v1/me/events\" -d '' -X POST \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer e011eb6d6b2829b8ebf14fdf1c5eb7c9e626e468eb615ba4c76da736a1b56c5e\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/documentation/api/events/create_:_returns_401_status_code.json
+++ b/documentation/api/events/create_:_returns_401_status_code.json
@@ -33,8 +33,8 @@
         "Pragma": "no-cache",
         "WWW-Authenticate": "Bearer realm=\"Doorkeeper\", error=\"invalid_token\", error_description=\"The access token is invalid\"",
         "Content-Type": "text/html",
-        "X-Request-Id": "2f960e2c-8e7d-4a96-b4fc-7fc24c7655ce",
-        "X-Runtime": "0.001595",
+        "X-Request-Id": "cf8dd1e6-8993-4d7f-bc82-62b3ed3f7eb7",
+        "X-Runtime": "0.001535",
         "Vary": "Origin",
         "Content-Length": "0"
       },

--- a/documentation/api/events/create_:_returns_422_status_code.json
+++ b/documentation/api/events/create_:_returns_422_status_code.json
@@ -19,7 +19,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 79e96cd6c3cd2f6fe05f774534bb5e43929c9747ffeaa0f1becee1c4cb9ff01d",
+        "Authorization": "Bearer 471048f05f9b9761ecf0cf4fc521ab2b028a9cc6f73c4fb4d77c6e85f33fd9f7",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -37,13 +37,13 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/vnd.api+json; charset=utf-8",
-        "X-Request-Id": "33ed6fca-f58f-40ca-9ef3-f69a7bfe1696",
-        "X-Runtime": "0.013686",
+        "X-Request-Id": "06488740-2af9-44e2-a45c-8acbf12a5a8f",
+        "X-Runtime": "0.010745",
         "Vary": "Origin",
         "Content-Length": "390"
       },
       "response_content_type": "application/vnd.api+json; charset=utf-8",
-      "curl": "curl \"http://localhost:3000api/v1/me/events\" -d '{\"data\":{\"type\":\"event\",\"attributes\":{\"title\":null,\"status\":null,\"start_at\":null,\"end_at\":null,\"timezone\":\"wat timezone\"}}}' -X POST \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 79e96cd6c3cd2f6fe05f774534bb5e43929c9747ffeaa0f1becee1c4cb9ff01d\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000api/v1/me/events\" -d '{\"data\":{\"type\":\"event\",\"attributes\":{\"title\":null,\"status\":null,\"start_at\":null,\"end_at\":null,\"timezone\":\"wat timezone\"}}}' -X POST \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 471048f05f9b9761ecf0cf4fc521ab2b028a9cc6f73c4fb4d77c6e85f33fd9f7\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/documentation/api/events/delete_:_returns_401_status_code.json
+++ b/documentation/api/events/delete_:_returns_401_status_code.json
@@ -33,8 +33,8 @@
         "Pragma": "no-cache",
         "WWW-Authenticate": "Bearer realm=\"Doorkeeper\", error=\"invalid_token\", error_description=\"The access token is invalid\"",
         "Content-Type": "text/html",
-        "X-Request-Id": "4802ef87-7ebe-4048-b424-60c17d49ce2c",
-        "X-Runtime": "0.002014",
+        "X-Request-Id": "7807b927-5b75-4de2-983a-af27ebd3b6c5",
+        "X-Runtime": "0.001600",
         "Vary": "Origin",
         "Content-Length": "0"
       },

--- a/documentation/api/events/delete_:_returns_404_status_code.json
+++ b/documentation/api/events/delete_:_returns_404_status_code.json
@@ -19,7 +19,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 752d9edc68e45dfa4bd1f87d6e9f6c78fc8404374ba73c8f3e27af48c8d5cf8c",
+        "Authorization": "Bearer f58b15f535745a159bbc24f70c5dd3baf331b35b6da0895a277b7ca84e5f7383",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -37,13 +37,13 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/vnd.api+json; charset=utf-8",
-        "X-Request-Id": "0f624abb-955f-406c-a4b4-f626f683fdc9",
-        "X-Runtime": "0.005892",
+        "X-Request-Id": "b2d1d34c-5dbb-480a-aed5-7d74e3f16d25",
+        "X-Runtime": "0.009722",
         "Vary": "Origin",
         "Content-Length": "109"
       },
       "response_content_type": "application/vnd.api+json; charset=utf-8",
-      "curl": "curl \"http://localhost:3000api/v1/me/events/0\" -d '' -X DELETE \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 752d9edc68e45dfa4bd1f87d6e9f6c78fc8404374ba73c8f3e27af48c8d5cf8c\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000api/v1/me/events/0\" -d '' -X DELETE \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer f58b15f535745a159bbc24f70c5dd3baf331b35b6da0895a277b7ca84e5f7383\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/documentation/api/events/index_:_retrieve_events_created_by_authenticated_user.json
+++ b/documentation/api/events/index_:_retrieve_events_created_by_authenticated_user.json
@@ -19,7 +19,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 83bcb912415eb6d93ce03be2bc3022502e2ef7f04f8e432a021b429595bccf9e",
+        "Authorization": "Bearer 4a47d3eb4be5006625fc852c78cb35f904f21397442dee12a6f9757d2c7ec493",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -28,7 +28,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 200,
       "response_status_text": "OK",
-      "response_body": "{\n  \"data\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"event\",\n      \"attributes\": {\n        \"title\": \"Quaerat temporibus ut omnis.\",\n        \"description\": null,\n        \"status\": \"confirmed\",\n        \"recurrence\": [\n          \"EXDATE;VALUE=DATE:20150610\",\n          \"RDATE;VALUE=DATE:20150609,20150611\",\n          \"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"\n        ],\n        \"start_at\": \"2019-02-11T00:00:00.000Z\",\n        \"end_at\": null,\n        \"timezone\": \"Etc/GMT+12\",\n        \"created_at\": \"2019-02-10T16:03:15.789Z\",\n        \"updated_at\": \"2019-02-10T16:03:15.789Z\"\n      },\n      \"relationships\": {\n        \"creator\": {\n          \"data\": {\n            \"id\": \"2\",\n            \"type\": \"creator\"\n          }\n        }\n      }\n    }\n  ]\n}",
+      "response_body": "{\n  \"data\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"event\",\n      \"attributes\": {\n        \"title\": \"Quisquam non dignissimos autem.\",\n        \"description\": null,\n        \"status\": \"confirmed\",\n        \"recurrence\": [\n          \"EXDATE;VALUE=DATE:20150610\",\n          \"RDATE;VALUE=DATE:20150609,20150611\",\n          \"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"\n        ],\n        \"start_at\": \"2019-02-15T00:00:00.000Z\",\n        \"end_at\": null,\n        \"timezone\": \"Etc/GMT+12\",\n        \"created_at\": \"2019-02-14T11:53:44.780Z\",\n        \"updated_at\": \"2019-02-14T11:53:44.780Z\"\n      },\n      \"relationships\": {\n        \"creator\": {\n          \"data\": {\n            \"id\": \"2\",\n            \"type\": \"creator\"\n          }\n        }\n      }\n    }\n  ]\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -37,14 +37,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/vnd.api+json; charset=utf-8",
-        "ETag": "W/\"8ee2dd052259d282169500f3586c879b\"",
-        "X-Request-Id": "43f2306b-3ab5-4156-b8e5-33167f049dca",
-        "X-Runtime": "0.027972",
+        "ETag": "W/\"1ec4002275334f9b725f14827b05da25\"",
+        "X-Request-Id": "7055a944-ca15-4d2a-a80e-775b1837a49a",
+        "X-Runtime": "0.040714",
         "Vary": "Origin",
-        "Content-Length": "477"
+        "Content-Length": "480"
       },
       "response_content_type": "application/vnd.api+json; charset=utf-8",
-      "curl": "curl -g \"http://localhost:3000api/v1/me/events\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 83bcb912415eb6d93ce03be2bc3022502e2ef7f04f8e432a021b429595bccf9e\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl -g \"http://localhost:3000api/v1/me/events\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 4a47d3eb4be5006625fc852c78cb35f904f21397442dee12a6f9757d2c7ec493\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/documentation/api/events/index_:_returns_401_status_code.json
+++ b/documentation/api/events/index_:_returns_401_status_code.json
@@ -33,8 +33,8 @@
         "Pragma": "no-cache",
         "WWW-Authenticate": "Bearer realm=\"Doorkeeper\", error=\"invalid_token\", error_description=\"The access token is invalid\"",
         "Content-Type": "text/html",
-        "X-Request-Id": "fe45a320-7d66-486c-a3d7-b0ed4d1febe8",
-        "X-Runtime": "0.002010",
+        "X-Request-Id": "10bb5f8b-e6a7-4244-923d-33ccab463da4",
+        "X-Runtime": "0.002699",
         "Vary": "Origin",
         "Content-Length": "0"
       },

--- a/documentation/api/events/show_:_retrieve_information_about_requested_event.json
+++ b/documentation/api/events/show_:_retrieve_information_about_requested_event.json
@@ -19,7 +19,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 3317406065d9c68d7ccde71dc09635c1092d9f19ed49a7e70e36e00a7042bde3",
+        "Authorization": "Bearer 518d267148c5bcb8bc8a3b473ce488b6555bbf4ca050ba8700dbab172de11a9d",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -28,7 +28,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 200,
       "response_status_text": "OK",
-      "response_body": "{\n  \"data\": {\n    \"id\": \"3\",\n    \"type\": \"event\",\n    \"attributes\": {\n      \"title\": \"some_new_event\",\n      \"description\": null,\n      \"status\": \"confirmed\",\n      \"recurrence\": [\n        \"EXDATE;VALUE=DATE:20150610\",\n        \"RDATE;VALUE=DATE:20150609,20150611\",\n        \"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"\n      ],\n      \"start_at\": \"2019-02-11T00:00:00.000Z\",\n      \"end_at\": null,\n      \"timezone\": \"Etc/GMT+12\",\n      \"created_at\": \"2019-02-10T16:03:15.950Z\",\n      \"updated_at\": \"2019-02-10T16:03:15.950Z\"\n    },\n    \"relationships\": {\n      \"creator\": {\n        \"data\": {\n          \"id\": \"6\",\n          \"type\": \"creator\"\n        }\n      }\n    }\n  }\n}",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"3\",\n    \"type\": \"event\",\n    \"attributes\": {\n      \"title\": \"some_new_event\",\n      \"description\": null,\n      \"status\": \"confirmed\",\n      \"recurrence\": [\n        \"EXDATE;VALUE=DATE:20150610\",\n        \"RDATE;VALUE=DATE:20150609,20150611\",\n        \"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"\n      ],\n      \"start_at\": \"2019-02-15T00:00:00.000Z\",\n      \"end_at\": null,\n      \"timezone\": \"Etc/GMT+12\",\n      \"created_at\": \"2019-02-14T11:53:44.960Z\",\n      \"updated_at\": \"2019-02-14T11:53:44.960Z\"\n    },\n    \"relationships\": {\n      \"creator\": {\n        \"data\": {\n          \"id\": \"6\",\n          \"type\": \"creator\"\n        }\n      }\n    }\n  }\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -37,14 +37,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/vnd.api+json; charset=utf-8",
-        "ETag": "W/\"c36ce4f6b11df62f8bbe767edb04b8d1\"",
-        "X-Request-Id": "106c456a-a90a-4c8e-aac9-1fd1a19e25af",
-        "X-Runtime": "0.012232",
+        "ETag": "W/\"13f1061f933076e531b6fc39f82ba9bd\"",
+        "X-Request-Id": "65288030-398c-4b9f-bc4b-355685fea85b",
+        "X-Runtime": "0.011814",
         "Vary": "Origin",
         "Content-Length": "461"
       },
       "response_content_type": "application/vnd.api+json; charset=utf-8",
-      "curl": "curl -g \"http://localhost:3000api/v1/me/events/3\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 3317406065d9c68d7ccde71dc09635c1092d9f19ed49a7e70e36e00a7042bde3\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl -g \"http://localhost:3000api/v1/me/events/3\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 518d267148c5bcb8bc8a3b473ce488b6555bbf4ca050ba8700dbab172de11a9d\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/documentation/api/events/show_:_returns_404_status_code.json
+++ b/documentation/api/events/show_:_returns_404_status_code.json
@@ -19,7 +19,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 1582247cea6e6f0128e1751144109b298f813fafd548413606fb4869c23a8ecb",
+        "Authorization": "Bearer 16cd85d83c183204abd1089b2c5c1ff588b3cd23eb7def3d1d7eccc6a44e3ab6",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -37,13 +37,13 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/vnd.api+json; charset=utf-8",
-        "X-Request-Id": "e98480e1-a538-446f-8505-e2fbf37d4e5f",
-        "X-Runtime": "0.007129",
+        "X-Request-Id": "4e3b9856-572d-4fe7-8202-6a6654281b5a",
+        "X-Runtime": "0.006922",
         "Vary": "Origin",
         "Content-Length": "109"
       },
       "response_content_type": "application/vnd.api+json; charset=utf-8",
-      "curl": "curl -g \"http://localhost:3000api/v1/me/events/0\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 1582247cea6e6f0128e1751144109b298f813fafd548413606fb4869c23a8ecb\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl -g \"http://localhost:3000api/v1/me/events/0\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 16cd85d83c183204abd1089b2c5c1ff588b3cd23eb7def3d1d7eccc6a44e3ab6\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/documentation/api/events/update_:_returns_400_status_code.json
+++ b/documentation/api/events/update_:_returns_400_status_code.json
@@ -19,7 +19,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer de2f9032f48caa87fac79686e6425dab5e324d4eea72f083ee64d7c1b873e63e",
+        "Authorization": "Bearer 7b0a26fd61a28fb4e82c8ec2c734b8d2e984568a991bde07d7127ea531a91c95",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -37,13 +37,13 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/vnd.api+json; charset=utf-8",
-        "X-Request-Id": "94a50a5e-cb92-418a-9eac-df5eba27bc02",
-        "X-Runtime": "0.007525",
+        "X-Request-Id": "35332c69-b525-42c2-a350-03eb77abdd51",
+        "X-Runtime": "0.007452",
         "Vary": "Origin",
         "Content-Length": "239"
       },
       "response_content_type": "application/vnd.api+json; charset=utf-8",
-      "curl": "curl \"http://localhost:3000api/v1/me/events/8\" -d '' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer de2f9032f48caa87fac79686e6425dab5e324d4eea72f083ee64d7c1b873e63e\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000api/v1/me/events/8\" -d '' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 7b0a26fd61a28fb4e82c8ec2c734b8d2e984568a991bde07d7127ea531a91c95\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/documentation/api/events/update_:_returns_401_status_code.json
+++ b/documentation/api/events/update_:_returns_401_status_code.json
@@ -33,8 +33,8 @@
         "Pragma": "no-cache",
         "WWW-Authenticate": "Bearer realm=\"Doorkeeper\", error=\"invalid_token\", error_description=\"The access token is invalid\"",
         "Content-Type": "text/html",
-        "X-Request-Id": "7db407b5-be0b-4523-9478-a8c52fbd00f3",
-        "X-Runtime": "0.001356",
+        "X-Request-Id": "c19326c6-d25f-47cb-91d6-3a56bdac0290",
+        "X-Runtime": "0.001591",
         "Vary": "Origin",
         "Content-Length": "0"
       },

--- a/documentation/api/events/update_:_returns_404_status_code.json
+++ b/documentation/api/events/update_:_returns_404_status_code.json
@@ -19,7 +19,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 34ca0b90b79a738345d5851065970b8414f73637273866b0f7613a3af1cf7c92",
+        "Authorization": "Bearer 9a28e86beec474ef02701b4887677ff9ca958c77a0546ad31286b6e01fc6d248",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -37,13 +37,13 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/vnd.api+json; charset=utf-8",
-        "X-Request-Id": "68bd795e-ee92-494a-9ff1-4e7c7ed45f27",
-        "X-Runtime": "0.005898",
+        "X-Request-Id": "5b9332ec-bd5e-4cb5-abdf-1d38889db69b",
+        "X-Runtime": "0.006140",
         "Vary": "Origin",
         "Content-Length": "109"
       },
       "response_content_type": "application/vnd.api+json; charset=utf-8",
-      "curl": "curl \"http://localhost:3000api/v1/me/events/0\" -d '' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 34ca0b90b79a738345d5851065970b8414f73637273866b0f7613a3af1cf7c92\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000api/v1/me/events/0\" -d '' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 9a28e86beec474ef02701b4887677ff9ca958c77a0546ad31286b6e01fc6d248\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/documentation/api/events/update_:_returns_422_status_code.json
+++ b/documentation/api/events/update_:_returns_422_status_code.json
@@ -19,7 +19,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer ed5282cfbc0f7acd8531b9299627e207ff9c9a43a2188468d709d7f86e51147c",
+        "Authorization": "Bearer 7d548ab6f89833e9facc5bf71216cc36d659668774fcae30798fd99fedb6cec7",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -37,13 +37,13 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/vnd.api+json; charset=utf-8",
-        "X-Request-Id": "e6e86482-ae4e-4138-b5a4-df832f26e1e8",
-        "X-Runtime": "0.009768",
+        "X-Request-Id": "32d966e2-223b-4d32-b14f-1d770068bf55",
+        "X-Runtime": "0.009646",
         "Vary": "Origin",
         "Content-Length": "390"
       },
       "response_content_type": "application/vnd.api+json; charset=utf-8",
-      "curl": "curl \"http://localhost:3000api/v1/me/events/9\" -d '{\"data\":{\"type\":\"event\",\"attributes\":{\"title\":null,\"status\":null,\"start_at\":null,\"end_at\":null,\"timezone\":\"wat timezone\"}}}' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer ed5282cfbc0f7acd8531b9299627e207ff9c9a43a2188468d709d7f86e51147c\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000api/v1/me/events/9\" -d '{\"data\":{\"type\":\"event\",\"attributes\":{\"title\":null,\"status\":null,\"start_at\":null,\"end_at\":null,\"timezone\":\"wat timezone\"}}}' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 7d548ab6f89833e9facc5bf71216cc36d659668774fcae30798fd99fedb6cec7\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/documentation/api/events/update_:_updates_selected_event_information.json
+++ b/documentation/api/events/update_:_updates_selected_event_information.json
@@ -66,11 +66,11 @@
     {
       "request_method": "PUT",
       "request_path": "api/v1/me/events/6",
-      "request_body": "{\"data\":{\"type\":\"event\",\"attributes\":{\"title\":\"Iusto dicta voluptas.\",\"description\":\"Quo ex quod. Quod vel reiciendis. Eligendi ea dolorum. Ullam praesentium ipsum. In dolor qui.\",\"status\":\"cancelled\",\"start_at\":\"2019-02-09\",\"end_at\":\"2019-02-11\",\"timezone\":\"Etc/GMT+12\",\"recurrence\":[\"EXDATE;VALUE=DATE:20150610\",\"RDATE;VALUE=DATE:20150609,20150611\",\"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"]}}}",
+      "request_body": "{\"data\":{\"type\":\"event\",\"attributes\":{\"title\":\"Similique laudantium dolores.\",\"description\":\"Commodi enim et. Consectetur occaecati voluptates. Quasi veritatis qui. Reprehenderit voluptatem veniam. Sapiente vel corrupti.\",\"status\":\"cancelled\",\"start_at\":\"2019-02-13\",\"end_at\":\"2019-02-15\",\"timezone\":\"Etc/GMT+12\",\"recurrence\":[\"EXDATE;VALUE=DATE:20150610\",\"RDATE;VALUE=DATE:20150609,20150611\",\"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"]}}}",
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer c468f578cd45ba20f0ccafcddeec7c10be1793675ad6ee9737dd2c47a01cfffc",
+        "Authorization": "Bearer fbd00d5eb089c63f2521990eeeaa88420fc518c712cb091f178948e7fb68d086",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -79,7 +79,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 200,
       "response_status_text": "OK",
-      "response_body": "{\n  \"data\": {\n    \"id\": \"6\",\n    \"type\": \"event\",\n    \"attributes\": {\n      \"title\": \"Iusto dicta voluptas.\",\n      \"description\": \"Quo ex quod. Quod vel reiciendis. Eligendi ea dolorum. Ullam praesentium ipsum. In dolor qui.\",\n      \"status\": \"cancelled\",\n      \"recurrence\": [\n        \"EXDATE;VALUE=DATE:20150610\",\n        \"RDATE;VALUE=DATE:20150609,20150611\",\n        \"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"\n      ],\n      \"start_at\": \"2019-02-09T00:00:00.000Z\",\n      \"end_at\": \"2019-02-11T00:00:00.000Z\",\n      \"timezone\": \"Etc/GMT+12\",\n      \"created_at\": \"2019-02-10T16:03:16.179Z\",\n      \"updated_at\": \"2019-02-10T16:03:16.191Z\"\n    },\n    \"relationships\": {\n      \"creator\": {\n        \"data\": {\n          \"id\": \"18\",\n          \"type\": \"creator\"\n        }\n      }\n    }\n  }\n}",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"6\",\n    \"type\": \"event\",\n    \"attributes\": {\n      \"title\": \"Similique laudantium dolores.\",\n      \"description\": \"Commodi enim et. Consectetur occaecati voluptates. Quasi veritatis qui. Reprehenderit voluptatem veniam. Sapiente vel corrupti.\",\n      \"status\": \"cancelled\",\n      \"recurrence\": [\n        \"EXDATE;VALUE=DATE:20150610\",\n        \"RDATE;VALUE=DATE:20150609,20150611\",\n        \"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"\n      ],\n      \"start_at\": \"2019-02-13T00:00:00.000Z\",\n      \"end_at\": \"2019-02-15T00:00:00.000Z\",\n      \"timezone\": \"Etc/GMT+12\",\n      \"created_at\": \"2019-02-14T11:53:45.218Z\",\n      \"updated_at\": \"2019-02-14T11:53:45.234Z\"\n    },\n    \"relationships\": {\n      \"creator\": {\n        \"data\": {\n          \"id\": \"18\",\n          \"type\": \"creator\"\n        }\n      }\n    }\n  }\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -88,14 +88,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/vnd.api+json; charset=utf-8",
-        "ETag": "W/\"0a970058d0bd01866f8e880955b7576d\"",
-        "X-Request-Id": "880aeb56-bbae-4780-9537-8c2a1ab52cf9",
-        "X-Runtime": "0.009817",
+        "ETag": "W/\"e7b47def915b86f6fc9c53ff280b9471\"",
+        "X-Request-Id": "9292eae6-1d76-4d12-85db-f6123e447eac",
+        "X-Runtime": "0.009814",
         "Vary": "Origin",
-        "Content-Length": "582"
+        "Content-Length": "624"
       },
       "response_content_type": "application/vnd.api+json; charset=utf-8",
-      "curl": "curl \"http://localhost:3000api/v1/me/events/6\" -d '{\"data\":{\"type\":\"event\",\"attributes\":{\"title\":\"Iusto dicta voluptas.\",\"description\":\"Quo ex quod. Quod vel reiciendis. Eligendi ea dolorum. Ullam praesentium ipsum. In dolor qui.\",\"status\":\"cancelled\",\"start_at\":\"2019-02-09\",\"end_at\":\"2019-02-11\",\"timezone\":\"Etc/GMT+12\",\"recurrence\":[\"EXDATE;VALUE=DATE:20150610\",\"RDATE;VALUE=DATE:20150609,20150611\",\"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"]}}}' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer c468f578cd45ba20f0ccafcddeec7c10be1793675ad6ee9737dd2c47a01cfffc\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000api/v1/me/events/6\" -d '{\"data\":{\"type\":\"event\",\"attributes\":{\"title\":\"Similique laudantium dolores.\",\"description\":\"Commodi enim et. Consectetur occaecati voluptates. Quasi veritatis qui. Reprehenderit voluptatem veniam. Sapiente vel corrupti.\",\"status\":\"cancelled\",\"start_at\":\"2019-02-13\",\"end_at\":\"2019-02-15\",\"timezone\":\"Etc/GMT+12\",\"recurrence\":[\"EXDATE;VALUE=DATE:20150610\",\"RDATE;VALUE=DATE:20150609,20150611\",\"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"]}}}' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer fbd00d5eb089c63f2521990eeeaa88420fc518c712cb091f178948e7fb68d086\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/documentation/api/groups/create_:_creates_new_group.json
+++ b/documentation/api/groups/create_:_creates_new_group.json
@@ -1,0 +1,67 @@
+{
+  "resource": "groups",
+  "resource_explanation": "El Plano groups API",
+  "http_method": "POST",
+  "route": "api/v1/group",
+  "description": "CREATE : Creates new group",
+  "explanation": "Create and return created group\n",
+  "parameters": [
+    {
+      "scope": [
+        "dta",
+        "attributes"
+      ],
+      "requred": true,
+      "name": "title",
+      "description": "Human readable identity)"
+    },
+    {
+      "scope": [
+        "dta",
+        "attributes"
+      ],
+      "requred": true,
+      "name": "number",
+      "description": "Main group identity"
+    }
+  ],
+  "response_fields": [
+
+  ],
+  "requests": [
+    {
+      "request_method": "POST",
+      "request_path": "api/v1/group",
+      "request_body": "{\"data\":{\"type\":\"group\",\"attributes\":{\"title\":\"Non reiciendis delectus.\",\"number\":\"60989\"}}}",
+      "request_headers": {
+        "Accept": "application/vnd.api+json",
+        "Content-Type": "application/vnd.api+json",
+        "Authorization": "Bearer 10e8b2bdb869b7e83ad62d44151c1067c92a2c43406cbcf3e92cd43b6a1c3a35",
+        "Host": "example.org",
+        "Cookie": ""
+      },
+      "request_query_parameters": {
+      },
+      "request_content_type": "application/vnd.api+json",
+      "response_status": 201,
+      "response_status_text": "Created",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"18\",\n    \"type\": \"group\",\n    \"attributes\": {\n      \"number\": \"60989\",\n      \"title\": \"Non reiciendis delectus.\",\n      \"created_at\": \"2019-02-14T11:53:45.572Z\",\n      \"updated_at\": \"2019-02-14T11:53:45.572Z\"\n    },\n    \"relationships\": {\n      \"students\": {\n        \"data\": [\n          {\n            \"id\": \"34\",\n            \"type\": \"student\"\n          }\n        ]\n      }\n    }\n  }\n}",
+      "response_headers": {
+        "Page-Title": "El+Plano",
+        "X-Frame-Options": "DENY",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "Cache-Control": "max-age=0, private, must-revalidate, no-store",
+        "Pragma": "no-cache",
+        "Content-Type": "application/vnd.api+json; charset=utf-8",
+        "ETag": "W/\"53fec5d8d747e71ace8946c295ad526f\"",
+        "X-Request-Id": "c001a28a-a2bb-4194-9653-1442209de15c",
+        "X-Runtime": "0.016798",
+        "Vary": "Origin",
+        "Content-Length": "251"
+      },
+      "response_content_type": "application/vnd.api+json; charset=utf-8",
+      "curl": "curl \"http://localhost:3000api/v1/group\" -d '{\"data\":{\"type\":\"group\",\"attributes\":{\"title\":\"Non reiciendis delectus.\",\"number\":\"60989\"}}}' -X POST \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 10e8b2bdb869b7e83ad62d44151c1067c92a2c43406cbcf3e92cd43b6a1c3a35\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+    }
+  ]
+}

--- a/documentation/api/groups/create_:_returns_400_status_code.json
+++ b/documentation/api/groups/create_:_returns_400_status_code.json
@@ -1,9 +1,9 @@
 {
-  "resource": "Students",
-  "resource_explanation": "El Plano student's profile API",
-  "http_method": "PUT",
-  "route": "api/v1/me/student",
-  "description": "UPDATE : Returns 400 status code",
+  "resource": "groups",
+  "resource_explanation": "El Plano groups API",
+  "http_method": "POST",
+  "route": "api/v1/group",
+  "description": "CREATE : Returns 400 status code",
   "explanation": "Returns 400 status code in case of missing parameters\n",
   "parameters": [
 
@@ -13,13 +13,13 @@
   ],
   "requests": [
     {
-      "request_method": "PUT",
-      "request_path": "api/v1/me/student",
+      "request_method": "POST",
+      "request_path": "api/v1/group",
       "request_body": null,
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 792ddec48c0e288cdd913f7d2af51b76097eed11a7d9b6ce2ed77dfb7c7a273a",
+        "Authorization": "Bearer cb9e99ba8a4c207b1824e93d80d5cce68ce8d502298f35459ccfb21b99562b5d",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -37,13 +37,13 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/vnd.api+json; charset=utf-8",
-        "X-Request-Id": "dac23a9a-4fd7-47f6-acfc-a2d27152517e",
-        "X-Runtime": "0.005270",
+        "X-Request-Id": "824db06c-6747-4b87-a9ea-d1a0c67db2c5",
+        "X-Runtime": "0.007346",
         "Vary": "Origin",
         "Content-Length": "239"
       },
       "response_content_type": "application/vnd.api+json; charset=utf-8",
-      "curl": "curl \"http://localhost:3000api/v1/me/student\" -d '' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 792ddec48c0e288cdd913f7d2af51b76097eed11a7d9b6ce2ed77dfb7c7a273a\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000api/v1/group\" -d '' -X POST \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer cb9e99ba8a4c207b1824e93d80d5cce68ce8d502298f35459ccfb21b99562b5d\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/documentation/api/groups/create_:_returns_401_status_code.json
+++ b/documentation/api/groups/create_:_returns_401_status_code.json
@@ -1,9 +1,9 @@
 {
-  "resource": "Events",
-  "resource_explanation": "El Plano events API",
-  "http_method": "GET",
-  "route": "api/v1/me/events/:id",
-  "description": "SHOW : Returns 401 status code",
+  "resource": "groups",
+  "resource_explanation": "El Plano groups API",
+  "http_method": "POST",
+  "route": "api/v1/group",
+  "description": "CREATE : Returns 401 status code",
   "explanation": "Returns 401 status code in case of missing or invalid access token\n",
   "parameters": [
 
@@ -13,12 +13,13 @@
   ],
   "requests": [
     {
-      "request_method": "GET",
-      "request_path": "api/v1/me/events/4",
+      "request_method": "POST",
+      "request_path": "api/v1/group",
       "request_body": null,
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
+        "Authorization": null,
         "Host": "example.org",
         "Cookie": ""
       },
@@ -33,13 +34,13 @@
         "Pragma": "no-cache",
         "WWW-Authenticate": "Bearer realm=\"Doorkeeper\", error=\"invalid_token\", error_description=\"The access token is invalid\"",
         "Content-Type": "text/html",
-        "X-Request-Id": "54698a4b-c45b-4f9d-b5e2-2c9b981c8b3a",
-        "X-Runtime": "0.003514",
+        "X-Request-Id": "8deafbb0-049e-4acf-b732-566ce430d2c9",
+        "X-Runtime": "0.001535",
         "Vary": "Origin",
         "Content-Length": "0"
       },
       "response_content_type": "text/html",
-      "curl": "curl -g \"http://localhost:3000api/v1/me/events/4\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000api/v1/group\" -d '' -X POST \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: \" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/documentation/api/groups/create_:_returns_403_status_code.json
+++ b/documentation/api/groups/create_:_returns_403_status_code.json
@@ -1,0 +1,49 @@
+{
+  "resource": "groups",
+  "resource_explanation": "El Plano groups API",
+  "http_method": "DELETE",
+  "route": "api/v1/group",
+  "description": "CREATE : Returns 403 status code",
+  "explanation": "Returns 403 status code in case in user has no access to action\n",
+  "parameters": [
+
+  ],
+  "response_fields": [
+
+  ],
+  "requests": [
+    {
+      "request_method": "DELETE",
+      "request_path": "api/v1/group",
+      "request_body": null,
+      "request_headers": {
+        "Accept": "application/vnd.api+json",
+        "Content-Type": "application/vnd.api+json",
+        "Authorization": "Bearer 81ccc4fbb6626a2c0bf19914fba6ff28e02df84c85aa42a749f30ffab6a2196f",
+        "Host": "example.org",
+        "Cookie": ""
+      },
+      "request_query_parameters": {
+      },
+      "request_content_type": "application/vnd.api+json",
+      "response_status": 403,
+      "response_status_text": "Forbidden",
+      "response_body": "{\n  \"errors\": [\n    {\n      \"status\": 403,\n      \"detail\": \"Auth error: Edit not allowed\",\n      \"source\": {\n        \"pointer\": \"authorization header\"\n      }\n    }\n  ]\n}",
+      "response_headers": {
+        "Page-Title": "El+Plano",
+        "X-Frame-Options": "DENY",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "Cache-Control": "max-age=0, private, must-revalidate, no-store",
+        "Pragma": "no-cache",
+        "Content-Type": "application/vnd.api+json; charset=utf-8",
+        "X-Request-Id": "2158596e-3654-4288-93f8-75d312dc3fd5",
+        "X-Runtime": "0.005893",
+        "Vary": "Origin",
+        "Content-Length": "111"
+      },
+      "response_content_type": "application/vnd.api+json; charset=utf-8",
+      "curl": "curl \"http://localhost:3000api/v1/group\" -d '' -X DELETE \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 81ccc4fbb6626a2c0bf19914fba6ff28e02df84c85aa42a749f30ffab6a2196f\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+    }
+  ]
+}

--- a/documentation/api/groups/create_:_returns_422_status_code.json
+++ b/documentation/api/groups/create_:_returns_422_status_code.json
@@ -1,0 +1,49 @@
+{
+  "resource": "groups",
+  "resource_explanation": "El Plano groups API",
+  "http_method": "POST",
+  "route": "api/v1/group",
+  "description": "CREATE : Returns 422 status code",
+  "explanation": "Returns 422 status code in case of invalid parameters\n",
+  "parameters": [
+
+  ],
+  "response_fields": [
+
+  ],
+  "requests": [
+    {
+      "request_method": "POST",
+      "request_path": "api/v1/group",
+      "request_body": "{\"data\":{\"type\":\"group\",\"attributes\":{\"title\":null,\"number\":null}}}",
+      "request_headers": {
+        "Accept": "application/vnd.api+json",
+        "Content-Type": "application/vnd.api+json",
+        "Authorization": "Bearer 08fec6414dc12ef4e8fc4e26a179612df3c6687d6261e3088e001e213a6c6d7d",
+        "Host": "example.org",
+        "Cookie": ""
+      },
+      "request_query_parameters": {
+      },
+      "request_content_type": "application/vnd.api+json",
+      "response_status": 422,
+      "response_status_text": "Unprocessable Entity",
+      "response_body": "{\n  \"errors\": [\n    {\n      \"status\": 422,\n      \"source\": {\n        \"pointer\": \"/data/attributes/number\"\n      },\n      \"detail\": \"can't be blank\"\n    }\n  ]\n}",
+      "response_headers": {
+        "Page-Title": "El+Plano",
+        "X-Frame-Options": "DENY",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "Cache-Control": "max-age=0, private, must-revalidate, no-store",
+        "Pragma": "no-cache",
+        "Content-Type": "application/vnd.api+json; charset=utf-8",
+        "X-Request-Id": "0144bf81-027a-453c-88ed-a4e8a66d0ac2",
+        "X-Runtime": "0.013720",
+        "Vary": "Origin",
+        "Content-Length": "100"
+      },
+      "response_content_type": "application/vnd.api+json; charset=utf-8",
+      "curl": "curl \"http://localhost:3000api/v1/group\" -d '{\"data\":{\"type\":\"group\",\"attributes\":{\"title\":null,\"number\":null}}}' -X POST \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 08fec6414dc12ef4e8fc4e26a179612df3c6687d6261e3088e001e213a6c6d7d\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+    }
+  ]
+}

--- a/documentation/api/groups/delete_:_deletes_user's_group.json
+++ b/documentation/api/groups/delete_:_deletes_user's_group.json
@@ -1,10 +1,10 @@
 {
-  "resource": "Events",
-  "resource_explanation": "El Plano events API",
+  "resource": "groups",
+  "resource_explanation": "El Plano groups API",
   "http_method": "DELETE",
-  "route": "api/v1/me/events/:id",
-  "description": "DELETE : Deletes selected event",
-  "explanation": "Deletes event\n",
+  "route": "api/v1/group",
+  "description": "DELETE : Deletes user's group",
+  "explanation": "Deletes group\n",
   "parameters": [
 
   ],
@@ -14,12 +14,12 @@
   "requests": [
     {
       "request_method": "DELETE",
-      "request_path": "api/v1/me/events/10",
+      "request_path": "api/v1/group",
       "request_body": null,
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 84bb34fdb251fa28a1c2f6466a291adf303586595b34105ebbcd2cfa6dd82466",
+        "Authorization": "Bearer 971d1cd01bedd424a168da0b2a2f9988dc2a1977f4bf9f5abaf1d59ccbf2c92e",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -36,12 +36,12 @@
         "X-Content-Type-Options": "nosniff",
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
-        "X-Request-Id": "b9ece01f-925f-42a1-8a33-d9018b90eea5",
-        "X-Runtime": "0.009633",
+        "X-Request-Id": "2067ca41-eea4-4448-94e4-e6cd4056ffb4",
+        "X-Runtime": "0.010685",
         "Vary": "Origin"
       },
       "response_content_type": null,
-      "curl": "curl \"http://localhost:3000api/v1/me/events/10\" -d '' -X DELETE \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 84bb34fdb251fa28a1c2f6466a291adf303586595b34105ebbcd2cfa6dd82466\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000api/v1/group\" -d '' -X DELETE \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 971d1cd01bedd424a168da0b2a2f9988dc2a1977f4bf9f5abaf1d59ccbf2c92e\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/documentation/api/groups/delete_:_returns_401_status_code.json
+++ b/documentation/api/groups/delete_:_returns_401_status_code.json
@@ -1,9 +1,9 @@
 {
-  "resource": "Events",
-  "resource_explanation": "El Plano events API",
-  "http_method": "GET",
-  "route": "api/v1/me/events/:id",
-  "description": "SHOW : Returns 401 status code",
+  "resource": "groups",
+  "resource_explanation": "El Plano groups API",
+  "http_method": "DELETE",
+  "route": "api/v1/group",
+  "description": "DELETE : Returns 401 status code",
   "explanation": "Returns 401 status code in case of missing or invalid access token\n",
   "parameters": [
 
@@ -13,12 +13,13 @@
   ],
   "requests": [
     {
-      "request_method": "GET",
-      "request_path": "api/v1/me/events/4",
+      "request_method": "DELETE",
+      "request_path": "api/v1/group",
       "request_body": null,
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
+        "Authorization": null,
         "Host": "example.org",
         "Cookie": ""
       },
@@ -33,13 +34,13 @@
         "Pragma": "no-cache",
         "WWW-Authenticate": "Bearer realm=\"Doorkeeper\", error=\"invalid_token\", error_description=\"The access token is invalid\"",
         "Content-Type": "text/html",
-        "X-Request-Id": "54698a4b-c45b-4f9d-b5e2-2c9b981c8b3a",
-        "X-Runtime": "0.003514",
+        "X-Request-Id": "0e6982b0-7e4d-44ba-b881-fef6fa2fe561",
+        "X-Runtime": "0.001581",
         "Vary": "Origin",
         "Content-Length": "0"
       },
       "response_content_type": "text/html",
-      "curl": "curl -g \"http://localhost:3000api/v1/me/events/4\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000api/v1/group\" -d '' -X DELETE \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: \" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/documentation/api/groups/show_:_retrieve_information_about_user's_group.json
+++ b/documentation/api/groups/show_:_retrieve_information_about_user's_group.json
@@ -1,0 +1,50 @@
+{
+  "resource": "groups",
+  "resource_explanation": "El Plano groups API",
+  "http_method": "GET",
+  "route": "api/v1/group",
+  "description": "SHOW : Retrieve information about user's group",
+  "explanation": "Returns detailed information about user's group\n\n`title` - Human readable group identity\n`number` - Main group identity\ntimestamps\n\nAlso, returns information about group members in relationships\n",
+  "parameters": [
+
+  ],
+  "response_fields": [
+
+  ],
+  "requests": [
+    {
+      "request_method": "GET",
+      "request_path": "api/v1/group",
+      "request_body": null,
+      "request_headers": {
+        "Accept": "application/vnd.api+json",
+        "Content-Type": "application/vnd.api+json",
+        "Authorization": "Bearer 46e63def4b8d1a24cec74f5b6c5951d7deaa725d4e7444f6936a4d67b4356732",
+        "Host": "example.org",
+        "Cookie": ""
+      },
+      "request_query_parameters": {
+      },
+      "request_content_type": "application/vnd.api+json",
+      "response_status": 200,
+      "response_status_text": "OK",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"17\",\n    \"type\": \"group\",\n    \"attributes\": {\n      \"number\": \"6035933833\",\n      \"title\": \"Adipisci exercitationem ut.\",\n      \"created_at\": \"2019-02-14T11:53:45.515Z\",\n      \"updated_at\": \"2019-02-14T11:53:45.515Z\"\n    },\n    \"relationships\": {\n      \"students\": {\n        \"data\": [\n          {\n            \"id\": \"33\",\n            \"type\": \"student\"\n          }\n        ]\n      }\n    }\n  }\n}",
+      "response_headers": {
+        "Page-Title": "El+Plano",
+        "X-Frame-Options": "DENY",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "Cache-Control": "max-age=0, private, must-revalidate, no-store",
+        "Pragma": "no-cache",
+        "Content-Type": "application/vnd.api+json; charset=utf-8",
+        "ETag": "W/\"71a9c19310a1768b278d6badbe9f0c82\"",
+        "X-Request-Id": "74f3dbe3-3a58-4716-8157-61eec1520063",
+        "X-Runtime": "0.012775",
+        "Vary": "Origin",
+        "Content-Length": "259"
+      },
+      "response_content_type": "application/vnd.api+json; charset=utf-8",
+      "curl": "curl -g \"http://localhost:3000api/v1/group\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 46e63def4b8d1a24cec74f5b6c5951d7deaa725d4e7444f6936a4d67b4356732\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+    }
+  ]
+}

--- a/documentation/api/groups/show_:_returns_401_status_code.json
+++ b/documentation/api/groups/show_:_returns_401_status_code.json
@@ -1,8 +1,8 @@
 {
-  "resource": "Events",
-  "resource_explanation": "El Plano events API",
+  "resource": "groups",
+  "resource_explanation": "El Plano groups API",
   "http_method": "GET",
-  "route": "api/v1/me/events/:id",
+  "route": "api/v1/group",
   "description": "SHOW : Returns 401 status code",
   "explanation": "Returns 401 status code in case of missing or invalid access token\n",
   "parameters": [
@@ -14,11 +14,12 @@
   "requests": [
     {
       "request_method": "GET",
-      "request_path": "api/v1/me/events/4",
+      "request_path": "api/v1/group",
       "request_body": null,
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
+        "Authorization": null,
         "Host": "example.org",
         "Cookie": ""
       },
@@ -33,13 +34,13 @@
         "Pragma": "no-cache",
         "WWW-Authenticate": "Bearer realm=\"Doorkeeper\", error=\"invalid_token\", error_description=\"The access token is invalid\"",
         "Content-Type": "text/html",
-        "X-Request-Id": "54698a4b-c45b-4f9d-b5e2-2c9b981c8b3a",
-        "X-Runtime": "0.003514",
+        "X-Request-Id": "2b1d9de9-7994-45a8-8395-f0730ef420af",
+        "X-Runtime": "0.001629",
         "Vary": "Origin",
         "Content-Length": "0"
       },
       "response_content_type": "text/html",
-      "curl": "curl -g \"http://localhost:3000api/v1/me/events/4\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl -g \"http://localhost:3000api/v1/group\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: \" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/documentation/api/groups/update_:_returns_400_status_code.json
+++ b/documentation/api/groups/update_:_returns_400_status_code.json
@@ -1,8 +1,8 @@
 {
-  "resource": "Students",
-  "resource_explanation": "El Plano student's profile API",
+  "resource": "groups",
+  "resource_explanation": "El Plano groups API",
   "http_method": "PUT",
-  "route": "api/v1/me/student",
+  "route": "api/v1/group",
   "description": "UPDATE : Returns 400 status code",
   "explanation": "Returns 400 status code in case of missing parameters\n",
   "parameters": [
@@ -14,12 +14,12 @@
   "requests": [
     {
       "request_method": "PUT",
-      "request_path": "api/v1/me/student",
+      "request_path": "api/v1/group",
       "request_body": null,
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 792ddec48c0e288cdd913f7d2af51b76097eed11a7d9b6ce2ed77dfb7c7a273a",
+        "Authorization": "Bearer fc17be1e3cb514b21d4eadce5b584f5f72fa59a69500a6d8af02764779273bde",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -37,13 +37,13 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/vnd.api+json; charset=utf-8",
-        "X-Request-Id": "dac23a9a-4fd7-47f6-acfc-a2d27152517e",
-        "X-Runtime": "0.005270",
+        "X-Request-Id": "ddad0f96-1600-41c5-9d87-44414387cd74",
+        "X-Runtime": "0.006679",
         "Vary": "Origin",
         "Content-Length": "239"
       },
       "response_content_type": "application/vnd.api+json; charset=utf-8",
-      "curl": "curl \"http://localhost:3000api/v1/me/student\" -d '' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 792ddec48c0e288cdd913f7d2af51b76097eed11a7d9b6ce2ed77dfb7c7a273a\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000api/v1/group\" -d '' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer fc17be1e3cb514b21d4eadce5b584f5f72fa59a69500a6d8af02764779273bde\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/documentation/api/groups/update_:_returns_401_status_code.json
+++ b/documentation/api/groups/update_:_returns_401_status_code.json
@@ -1,9 +1,9 @@
 {
-  "resource": "Events",
-  "resource_explanation": "El Plano events API",
-  "http_method": "GET",
-  "route": "api/v1/me/events/:id",
-  "description": "SHOW : Returns 401 status code",
+  "resource": "groups",
+  "resource_explanation": "El Plano groups API",
+  "http_method": "PUT",
+  "route": "api/v1/group",
+  "description": "UPDATE : Returns 401 status code",
   "explanation": "Returns 401 status code in case of missing or invalid access token\n",
   "parameters": [
 
@@ -13,12 +13,13 @@
   ],
   "requests": [
     {
-      "request_method": "GET",
-      "request_path": "api/v1/me/events/4",
+      "request_method": "PUT",
+      "request_path": "api/v1/group",
       "request_body": null,
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
+        "Authorization": null,
         "Host": "example.org",
         "Cookie": ""
       },
@@ -33,13 +34,13 @@
         "Pragma": "no-cache",
         "WWW-Authenticate": "Bearer realm=\"Doorkeeper\", error=\"invalid_token\", error_description=\"The access token is invalid\"",
         "Content-Type": "text/html",
-        "X-Request-Id": "54698a4b-c45b-4f9d-b5e2-2c9b981c8b3a",
-        "X-Runtime": "0.003514",
+        "X-Request-Id": "b65d3d5a-d4bd-4fd9-86c1-7d97263e7218",
+        "X-Runtime": "0.001437",
         "Vary": "Origin",
         "Content-Length": "0"
       },
       "response_content_type": "text/html",
-      "curl": "curl -g \"http://localhost:3000api/v1/me/events/4\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000api/v1/group\" -d '' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: \" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/documentation/api/groups/update_:_returns_422_status_code.json
+++ b/documentation/api/groups/update_:_returns_422_status_code.json
@@ -1,0 +1,49 @@
+{
+  "resource": "groups",
+  "resource_explanation": "El Plano groups API",
+  "http_method": "PUT",
+  "route": "api/v1/group",
+  "description": "UPDATE : Returns 422 status code",
+  "explanation": "Returns 422 status code in case of invalid parameters\n",
+  "parameters": [
+
+  ],
+  "response_fields": [
+
+  ],
+  "requests": [
+    {
+      "request_method": "PUT",
+      "request_path": "api/v1/group",
+      "request_body": "{\"data\":{\"type\":\"group\",\"attributes\":{\"title\":null,\"number\":null}}}",
+      "request_headers": {
+        "Accept": "application/vnd.api+json",
+        "Content-Type": "application/vnd.api+json",
+        "Authorization": "Bearer 1d066ebcd6cf2650f3df911e0d873ed4df89a8c54258e4dd1d930340c7777fc9",
+        "Host": "example.org",
+        "Cookie": ""
+      },
+      "request_query_parameters": {
+      },
+      "request_content_type": "application/vnd.api+json",
+      "response_status": 422,
+      "response_status_text": "Unprocessable Entity",
+      "response_body": "{\n  \"errors\": [\n    {\n      \"status\": 422,\n      \"source\": {\n        \"pointer\": \"/data/attributes/number\"\n      },\n      \"detail\": \"can't be blank\"\n    }\n  ]\n}",
+      "response_headers": {
+        "Page-Title": "El+Plano",
+        "X-Frame-Options": "DENY",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "Cache-Control": "max-age=0, private, must-revalidate, no-store",
+        "Pragma": "no-cache",
+        "Content-Type": "application/vnd.api+json; charset=utf-8",
+        "X-Request-Id": "76e6d27c-464e-4f3f-be3c-075e38b6dea0",
+        "X-Runtime": "0.011007",
+        "Vary": "Origin",
+        "Content-Length": "100"
+      },
+      "response_content_type": "application/vnd.api+json; charset=utf-8",
+      "curl": "curl \"http://localhost:3000api/v1/group\" -d '{\"data\":{\"type\":\"group\",\"attributes\":{\"title\":null,\"number\":null}}}' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 1d066ebcd6cf2650f3df911e0d873ed4df89a8c54258e4dd1d930340c7777fc9\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+    }
+  ]
+}

--- a/documentation/api/groups/update_:_updates_group_information.json
+++ b/documentation/api/groups/update_:_updates_group_information.json
@@ -1,0 +1,67 @@
+{
+  "resource": "groups",
+  "resource_explanation": "El Plano groups API",
+  "http_method": "PUT",
+  "route": "api/v1/group",
+  "description": "UPDATE : Updates group information",
+  "explanation": "Update and return updated group\n",
+  "parameters": [
+    {
+      "scope": [
+        "data",
+        "attributes"
+      ],
+      "requred": true,
+      "name": "title",
+      "description": "Human readable identity)"
+    },
+    {
+      "scope": [
+        "data",
+        "attributes"
+      ],
+      "requred": true,
+      "name": "number",
+      "description": "Main group identity"
+    }
+  ],
+  "response_fields": [
+
+  ],
+  "requests": [
+    {
+      "request_method": "PUT",
+      "request_path": "api/v1/group",
+      "request_body": "{\"data\":{\"type\":\"group\",\"attributes\":{\"title\":\"Aut dolor sapiente.\",\"number\":\"18560\"}}}",
+      "request_headers": {
+        "Accept": "application/vnd.api+json",
+        "Content-Type": "application/vnd.api+json",
+        "Authorization": "Bearer 989c5845f3975d927a500f53b0fed39b1023290f3a420c71887337764afe95c5",
+        "Host": "example.org",
+        "Cookie": ""
+      },
+      "request_query_parameters": {
+      },
+      "request_content_type": "application/vnd.api+json",
+      "response_status": 200,
+      "response_status_text": "OK",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"20\",\n    \"type\": \"group\",\n    \"attributes\": {\n      \"number\": \"18560\",\n      \"title\": \"Aut dolor sapiente.\",\n      \"created_at\": \"2019-02-14T11:53:45.692Z\",\n      \"updated_at\": \"2019-02-14T11:53:45.705Z\"\n    },\n    \"relationships\": {\n      \"students\": {\n        \"data\": [\n          {\n            \"id\": \"39\",\n            \"type\": \"student\"\n          }\n        ]\n      }\n    }\n  }\n}",
+      "response_headers": {
+        "Page-Title": "El+Plano",
+        "X-Frame-Options": "DENY",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "Cache-Control": "max-age=0, private, must-revalidate, no-store",
+        "Pragma": "no-cache",
+        "Content-Type": "application/vnd.api+json; charset=utf-8",
+        "ETag": "W/\"22428036b5387df1cb5b97063f7f7473\"",
+        "X-Request-Id": "806fd97d-9994-454c-8973-641b3a85b5a1",
+        "X-Runtime": "0.013351",
+        "Vary": "Origin",
+        "Content-Length": "246"
+      },
+      "response_content_type": "application/vnd.api+json; charset=utf-8",
+      "curl": "curl \"http://localhost:3000api/v1/group\" -d '{\"data\":{\"type\":\"group\",\"attributes\":{\"title\":\"Aut dolor sapiente.\",\"number\":\"18560\"}}}' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 989c5845f3975d927a500f53b0fed39b1023290f3a420c71887337764afe95c5\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+    }
+  ]
+}

--- a/documentation/api/index.json
+++ b/documentation/api/index.json
@@ -192,6 +192,117 @@
           "method": "get"
         }
       ]
+    },
+    {
+      "name": "groups",
+      "explanation": "El Plano groups API",
+      "examples": [
+        {
+          "description": "CREATE : Creates new group",
+          "link": "groups/create_:_creates_new_group.json",
+          "groups": "all",
+          "route": "api/v1/group",
+          "method": "post"
+        },
+        {
+          "description": "CREATE : Returns 400 status code",
+          "link": "groups/create_:_returns_400_status_code.json",
+          "groups": "all",
+          "route": "api/v1/group",
+          "method": "post"
+        },
+        {
+          "description": "CREATE : Returns 401 status code",
+          "link": "groups/create_:_returns_401_status_code.json",
+          "groups": "all",
+          "route": "api/v1/group",
+          "method": "post"
+        },
+        {
+          "description": "CREATE : Returns 403 status code",
+          "link": "groups/create_:_returns_403_status_code.json",
+          "groups": "all",
+          "route": "api/v1/group",
+          "method": "post"
+        },
+        {
+          "description": "CREATE : Returns 403 status code",
+          "link": "groups/create_:_returns_403_status_code.json",
+          "groups": "all",
+          "route": "api/v1/group",
+          "method": "put"
+        },
+        {
+          "description": "CREATE : Returns 403 status code",
+          "link": "groups/create_:_returns_403_status_code.json",
+          "groups": "all",
+          "route": "api/v1/group",
+          "method": "delete"
+        },
+        {
+          "description": "CREATE : Returns 422 status code",
+          "link": "groups/create_:_returns_422_status_code.json",
+          "groups": "all",
+          "route": "api/v1/group",
+          "method": "post"
+        },
+        {
+          "description": "DELETE : Deletes user's group",
+          "link": "groups/delete_:_deletes_user's_group.json",
+          "groups": "all",
+          "route": "api/v1/group",
+          "method": "delete"
+        },
+        {
+          "description": "DELETE : Returns 401 status code",
+          "link": "groups/delete_:_returns_401_status_code.json",
+          "groups": "all",
+          "route": "api/v1/group",
+          "method": "delete"
+        },
+        {
+          "description": "SHOW : Retrieve information about user's group",
+          "link": "groups/show_:_retrieve_information_about_user's_group.json",
+          "groups": "all",
+          "route": "api/v1/group",
+          "method": "get"
+        },
+        {
+          "description": "SHOW : Returns 401 status code",
+          "link": "groups/show_:_returns_401_status_code.json",
+          "groups": "all",
+          "route": "api/v1/group",
+          "method": "get"
+        },
+        {
+          "description": "UPDATE : Returns 400 status code",
+          "link": "groups/update_:_returns_400_status_code.json",
+          "groups": "all",
+          "route": "api/v1/group",
+          "method": "put"
+        },
+        {
+          "description": "UPDATE : Returns 401 status code",
+          "link": "groups/update_:_returns_401_status_code.json",
+          "groups": "all",
+          "route": "api/v1/group",
+          "method": "put"
+        },
+        {
+          "description": "UPDATE : Returns 422 status code",
+          "link": "groups/update_:_returns_422_status_code.json",
+          "groups": "all",
+          "route": "api/v1/group",
+          "method": "put"
+        },
+        {
+          "description": "UPDATE : Updates group information",
+          "link": "groups/update_:_updates_group_information.json",
+          "groups": "all",
+          "route": "api/v1/group",
+          "method": "put"
+        }
+      ]
     }
   ]
 }

--- a/documentation/api/students/show_:_retrieve_authenticated_users's_information.json
+++ b/documentation/api/students/show_:_retrieve_authenticated_users's_information.json
@@ -19,7 +19,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer a6335f19991ee8d083185d003a93701b7f3ad3ffceee78194e14759db835a4ec",
+        "Authorization": "Bearer 854f82feada486467bf928cf651d7e717c22eba227b5d277363a7b266b4a8e45",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -28,7 +28,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 200,
       "response_status_text": "OK",
-      "response_body": "{\n  \"data\": {\n    \"id\": \"34\",\n    \"type\": \"student\",\n    \"attributes\": {\n      \"full_name\": \"Mrs. Socorro Shanika Corwin\",\n      \"email\": \"talisha@okuneva.io\",\n      \"phone\": \"812-323-4305\",\n      \"about\": \"In aut eum. Rerum aspernatur nemo. Veritatis quasi non. Distinctio porro et. Ut quia vel.\",\n      \"social_networks\": {\n        \"twitter\": \"http://twitter/omega_ritchie\",\n        \"facebook\": \"http://facebook/je_sporer\"\n      },\n      \"president\": false,\n      \"created_at\": \"2019-02-10T16:03:16.455Z\",\n      \"updated_at\": \"2019-02-10T16:03:16.455Z\"\n    },\n    \"relationships\": {\n      \"group\": {\n        \"data\": {\n          \"id\": \"17\",\n          \"type\": \"group\"\n        }\n      }\n    }\n  },\n  \"included\": [\n    {\n      \"id\": \"17\",\n      \"type\": \"group\",\n      \"attributes\": {\n        \"number\": \"4087939459\",\n        \"title\": \"Tempora repellendus iusto.\",\n        \"created_at\": \"2019-02-10T16:03:16.452Z\",\n        \"updated_at\": \"2019-02-10T16:03:16.452Z\"\n      },\n      \"relationships\": {\n        \"students\": {\n          \"data\": [\n            {\n              \"id\": \"34\",\n              \"type\": \"student\"\n            }\n          ]\n        }\n      }\n    }\n  ]\n}",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"48\",\n    \"type\": \"student\",\n    \"attributes\": {\n      \"full_name\": \"Leandra Lovetta Hackett\",\n      \"email\": \"demetriusjones@jenkinswisoky.name\",\n      \"phone\": \"1-829-883-2613\",\n      \"about\": \"Sit et qui. Illum vitae et. Corporis ipsa soluta. Similique dicta est. Quod nisi nihil.\",\n      \"social_networks\": {\n        \"twitter\": \"http://twitter/brianna.zemlak\",\n        \"facebook\": \"http://facebook/eusebio_muller\"\n      },\n      \"president\": false,\n      \"created_at\": \"2019-02-14T11:53:45.919Z\",\n      \"updated_at\": \"2019-02-14T11:53:45.919Z\"\n    },\n    \"relationships\": {\n      \"group\": {\n        \"data\": {\n          \"id\": \"26\",\n          \"type\": \"group\"\n        }\n      }\n    }\n  },\n  \"included\": [\n    {\n      \"id\": \"26\",\n      \"type\": \"group\",\n      \"attributes\": {\n        \"number\": \"5458524103\",\n        \"title\": \"Et magnam maxime.\",\n        \"created_at\": \"2019-02-14T11:53:45.918Z\",\n        \"updated_at\": \"2019-02-14T11:53:45.918Z\"\n      },\n      \"relationships\": {\n        \"students\": {\n          \"data\": [\n            {\n              \"id\": \"48\",\n              \"type\": \"student\"\n            }\n          ]\n        }\n      }\n    }\n  ]\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -37,14 +37,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/vnd.api+json; charset=utf-8",
-        "ETag": "W/\"e9d1f5a37787dda0170346c5e5298395\"",
-        "X-Request-Id": "c7a58caa-6cb6-4107-a69c-b828361ecbb0",
-        "X-Runtime": "0.009852",
+        "ETag": "W/\"8a4a1b028f08369679afad36381df301\"",
+        "X-Request-Id": "10804ba0-7e95-4cc4-a8b4-65f6d7aff410",
+        "X-Runtime": "0.014408",
         "Vary": "Origin",
-        "Content-Length": "769"
+        "Content-Length": "777"
       },
       "response_content_type": "application/vnd.api+json; charset=utf-8",
-      "curl": "curl -g \"http://localhost:3000api/v1/me/student\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer a6335f19991ee8d083185d003a93701b7f3ad3ffceee78194e14759db835a4ec\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl -g \"http://localhost:3000api/v1/me/student\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 854f82feada486467bf928cf651d7e717c22eba227b5d277363a7b266b4a8e45\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/documentation/api/students/show_:_returns_401_status_code.json
+++ b/documentation/api/students/show_:_returns_401_status_code.json
@@ -33,8 +33,8 @@
         "Pragma": "no-cache",
         "WWW-Authenticate": "Bearer realm=\"Doorkeeper\", error=\"invalid_token\", error_description=\"The access token is invalid\"",
         "Content-Type": "text/html",
-        "X-Request-Id": "50546aeb-919e-4a58-a393-f964612671f0",
-        "X-Runtime": "0.001250",
+        "X-Request-Id": "e85b6bb0-2b1d-49df-a1b6-42ced0428966",
+        "X-Runtime": "0.001732",
         "Vary": "Origin",
         "Content-Length": "0"
       },

--- a/documentation/api/students/update_:_returns_401_status_code.json
+++ b/documentation/api/students/update_:_returns_401_status_code.json
@@ -33,8 +33,8 @@
         "Pragma": "no-cache",
         "WWW-Authenticate": "Bearer realm=\"Doorkeeper\", error=\"invalid_token\", error_description=\"The access token is invalid\"",
         "Content-Type": "text/html",
-        "X-Request-Id": "9b22d13e-1706-4c9a-930a-4bfbb32f7d13",
-        "X-Runtime": "0.001299",
+        "X-Request-Id": "f31f000b-2769-475a-8e72-5a18c6f27978",
+        "X-Runtime": "0.001384",
         "Vary": "Origin",
         "Content-Length": "0"
       },

--- a/documentation/api/students/update_:_returns_422_status_code.json
+++ b/documentation/api/students/update_:_returns_422_status_code.json
@@ -19,7 +19,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 803c6970ad2aa58bdf645d1da6b70fcc04078c0dde713c37bdc822c2da933c78",
+        "Authorization": "Bearer da4674466b360c05462cee0a569be9f0ca666b64666f321b91b5fe398c337bcc",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -37,13 +37,13 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/vnd.api+json; charset=utf-8",
-        "X-Request-Id": "019bd186-02c4-4005-95e8-1a92d7324ff9",
-        "X-Runtime": "0.006819",
+        "X-Request-Id": "8079b910-0fa2-4e68-a696-5da82c259f91",
+        "X-Runtime": "0.006977",
         "Vary": "Origin",
         "Content-Length": "123"
       },
       "response_content_type": "application/vnd.api+json; charset=utf-8",
-      "curl": "curl \"http://localhost:3000api/v1/me/student\" -d '{\"data\":{\"type\":\"student\",\"attributes\":{\"phone\":\"1123456789012345678901234567890123456789012345678901234567890\"}}}' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 803c6970ad2aa58bdf645d1da6b70fcc04078c0dde713c37bdc822c2da933c78\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000api/v1/me/student\" -d '{\"data\":{\"type\":\"student\",\"attributes\":{\"phone\":\"1123456789012345678901234567890123456789012345678901234567890\"}}}' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer da4674466b360c05462cee0a569be9f0ca666b64666f321b91b5fe398c337bcc\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/documentation/api/students/update_:_updates_authenticated_user's_information.json
+++ b/documentation/api/students/update_:_updates_authenticated_user's_information.json
@@ -58,7 +58,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 336f52bf38ed9b4021a4092b506c7d60b1210244caf2da1336f6b4228ff429ba",
+        "Authorization": "Bearer 14cf0a5119dae70ebf58114136cb7831c7faebc038cd952fe3354782d48b51bd",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -67,7 +67,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 200,
       "response_status_text": "OK",
-      "response_body": "{\n  \"data\": {\n    \"id\": \"36\",\n    \"type\": \"student\",\n    \"attributes\": {\n      \"full_name\": \"Sir Wat Name Yeah\",\n      \"email\": \"wat@wat.wat\",\n      \"phone\": \"+8 983 47 89 312\",\n      \"about\": \"Nihil dolorem voluptatem. Aliquid quia quisquam. Facilis magni commodi. Ut laboriosam debitis. Autem soluta aperiam.\",\n      \"social_networks\": {\n        \"twitter\": \"https://twitter.com/watever\",\n        \"facebook\": \"https://facebook.com/watever\"\n      },\n      \"president\": false,\n      \"created_at\": \"2019-02-10T16:03:16.500Z\",\n      \"updated_at\": \"2019-02-10T16:03:16.510Z\"\n    },\n    \"relationships\": {\n      \"group\": {\n        \"data\": {\n          \"id\": \"18\",\n          \"type\": \"group\"\n        }\n      }\n    }\n  }\n}",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"50\",\n    \"type\": \"student\",\n    \"attributes\": {\n      \"full_name\": \"Sir Wat Name Yeah\",\n      \"email\": \"wat@wat.wat\",\n      \"phone\": \"+8 983 47 89 312\",\n      \"about\": \"Placeat optio et. Cum rerum aperiam. Aut dolorem consequatur. Enim ab nemo. Quo sed assumenda.\",\n      \"social_networks\": {\n        \"twitter\": \"https://twitter.com/watever\",\n        \"facebook\": \"https://facebook.com/watever\"\n      },\n      \"president\": false,\n      \"created_at\": \"2019-02-14T11:53:45.973Z\",\n      \"updated_at\": \"2019-02-14T11:53:45.984Z\"\n    },\n    \"relationships\": {\n      \"group\": {\n        \"data\": {\n          \"id\": \"27\",\n          \"type\": \"group\"\n        }\n      }\n    }\n  }\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -76,14 +76,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/vnd.api+json; charset=utf-8",
-        "ETag": "W/\"3f0a25c50ff624fc8444f9b87c2e0478\"",
-        "X-Request-Id": "5b47e51e-cd95-4fc3-aecc-631ca8a0a4ee",
-        "X-Runtime": "0.008253",
+        "ETag": "W/\"e4dab6ff00e69a56afdd6550a56019a6\"",
+        "X-Request-Id": "72da19c7-cf9c-440e-8716-ef8740cbad48",
+        "X-Runtime": "0.008494",
         "Vary": "Origin",
-        "Content-Length": "522"
+        "Content-Length": "500"
       },
       "response_content_type": "application/vnd.api+json; charset=utf-8",
-      "curl": "curl \"http://localhost:3000api/v1/me/student\" -d '{\"data\":{\"type\":\"student\",\"attributes\":{\"email\":\"wat@wat.wat\",\"phone\":\"+8 983 47 89 312\",\"full_name\":\"Sir Wat Name Yeah\",\"social_networks\":{\"twitter\":\"https://twitter.com/watever\",\"facebook\":\"https://facebook.com/watever\"}}}}' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 336f52bf38ed9b4021a4092b506c7d60b1210244caf2da1336f6b4228ff429ba\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000api/v1/me/student\" -d '{\"data\":{\"type\":\"student\",\"attributes\":{\"email\":\"wat@wat.wat\",\"phone\":\"+8 983 47 89 312\",\"full_name\":\"Sir Wat Name Yeah\",\"social_networks\":{\"twitter\":\"https://twitter.com/watever\",\"facebook\":\"https://facebook.com/watever\"}}}}' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 14cf0a5119dae70ebf58114136cb7831c7faebc038cd952fe3354782d48b51bd\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/documentation/api/users/show_:_retrieve_authenticated_users's_profile.json
+++ b/documentation/api/users/show_:_retrieve_authenticated_users's_profile.json
@@ -19,7 +19,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 71b71933d94d7e5da49720af757825bbfea3565ccb6abfc41225837528a80a1a",
+        "Authorization": "Bearer c2dd78b5ec16311f81a188ba5e350e639be90d87287be5509b804d735d5d33f2",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -28,7 +28,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 200,
       "response_status_text": "OK",
-      "response_body": "{\n  \"data\": {\n    \"id\": \"41\",\n    \"type\": \"user\",\n    \"attributes\": {\n      \"email\": \"bernetta@ritchie.net\",\n      \"username\": \"jasper.stoltenberg\",\n      \"admin\": false,\n      \"created_at\": \"2019-02-10T16:03:16.598Z\",\n      \"updated_at\": \"2019-02-10T16:03:16.598Z\",\n      \"avatar_url\": \"https://www.gravatar.com/avatar/0745f6506b669a0bc4b599f8344c3ee9?s=200&d=identicon\",\n      \"confirmed\": true\n    },\n    \"relationships\": {\n      \"student\": {\n        \"data\": {\n          \"id\": \"41\",\n          \"type\": \"student\"\n        }\n      }\n    }\n  }\n}",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"55\",\n    \"type\": \"user\",\n    \"attributes\": {\n      \"email\": \"devona@mraz.org\",\n      \"username\": \"jeanette_mills\",\n      \"admin\": false,\n      \"created_at\": \"2019-02-14T11:53:46.067Z\",\n      \"updated_at\": \"2019-02-14T11:53:46.067Z\",\n      \"avatar_url\": \"https://www.gravatar.com/avatar/68cb87ce90029c1859cfa9bf4e859da4?s=200&d=identicon\",\n      \"confirmed\": true\n    },\n    \"relationships\": {\n      \"student\": {\n        \"data\": {\n          \"id\": \"55\",\n          \"type\": \"student\"\n        }\n      }\n    }\n  }\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -37,14 +37,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/vnd.api+json; charset=utf-8",
-        "ETag": "W/\"ec06228d848adec27df00ec24fb7149d\"",
-        "X-Request-Id": "cf25b6a0-df2c-459b-8f79-5855122ed0c1",
-        "X-Runtime": "0.679083",
+        "ETag": "W/\"8070d865bbe1922ff3aa7666634054bb\"",
+        "X-Request-Id": "e63bf443-c734-44bc-924c-fbc202822bbe",
+        "X-Runtime": "0.069942",
         "Vary": "Origin",
-        "Content-Length": "392"
+        "Content-Length": "383"
       },
       "response_content_type": "application/vnd.api+json; charset=utf-8",
-      "curl": "curl -g \"http://localhost:3000api/v1/me\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 71b71933d94d7e5da49720af757825bbfea3565ccb6abfc41225837528a80a1a\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl -g \"http://localhost:3000api/v1/me\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer c2dd78b5ec16311f81a188ba5e350e639be90d87287be5509b804d735d5d33f2\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/documentation/api/users/show_:_returns_401_status_code.json
+++ b/documentation/api/users/show_:_returns_401_status_code.json
@@ -33,8 +33,8 @@
         "Pragma": "no-cache",
         "WWW-Authenticate": "Bearer realm=\"Doorkeeper\", error=\"invalid_token\", error_description=\"The access token is invalid\"",
         "Content-Type": "text/html",
-        "X-Request-Id": "0b5f2f3e-4a0e-4455-bb95-68c6c494ddfd",
-        "X-Runtime": "0.001206",
+        "X-Request-Id": "f0872c57-84e7-4203-a85b-6375793505b3",
+        "X-Runtime": "0.003968",
         "Vary": "Origin",
         "Content-Length": "0"
       },

--- a/spec/acceptance/api/v1/groups_spec.rb
+++ b/spec/acceptance/api/v1/groups_spec.rb
@@ -1,0 +1,265 @@
+# frozen_string_literal: true
+
+require 'acceptance_helper'
+
+resource 'groups' do
+  explanation 'El Plano groups API'
+
+  let(:user)  { student.user }
+  let(:token) { create(:token, resource_owner_id: user.id).token }
+  let(:authorization) { "Bearer #{token}" }
+
+  let(:student) { create(:student, :group_supervisor) }
+  let(:group)   { student.group }
+
+  header 'Accept', 'application/vnd.api+json'
+  header 'Content-Type', 'application/vnd.api+json'
+  header 'Authorization', :authorization
+
+  get 'api/v1/group' do
+    context 'Authorized - 200' do
+      example "SHOW : Retrieve information about user's group" do
+        explanation <<~DESC
+          Returns detailed information about user's group
+
+          `title` - Human readable group identity
+          `number` - Main group identity
+          timestamps
+
+          Also, returns information about group members in relationships
+        DESC
+
+        do_request
+
+        expected_body = GroupSerializer.new(group).serialized_json.to_s
+
+        expect(status).to eq(200)
+        expect(response_body).to eq(expected_body)
+      end
+    end
+
+    context 'Unauthorized - 401' do
+      let(:authorization) { nil }
+
+      example 'SHOW : Returns 401 status code' do
+        explanation <<~DESC
+          Returns 401 status code in case of missing or invalid access token
+        DESC
+
+        do_request
+
+        expect(status).to eq(401)
+      end
+    end
+  end
+
+  post 'api/v1/group' do
+    let(:student) { create(:student) }
+
+    context 'Authorized - 201' do
+      with_options scope: %i[dta attributes] do
+        parameter :title, 'Human readable identity)', requred: true
+        parameter :number, 'Main group identity', requred: true
+      end
+
+      let(:raw_post) { { data: build(:group_params) }.to_json }
+
+      example 'CREATE : Creates new group' do
+        explanation <<~DESC
+          Create and return created group
+        DESC
+
+        do_request
+
+        expected_body = GroupSerializer
+                        .new(student.reload.group)
+                        .serialized_json
+                        .to_s
+
+        expect(status).to eq(201)
+        expect(response_body).to eq(expected_body)
+      end
+    end
+
+    context 'Unauthorized - 401' do
+      let(:authorization) { nil }
+
+      example 'CREATE : Returns 401 status code' do
+        explanation <<~DESC
+          Returns 401 status code in case of missing or invalid access token
+        DESC
+
+        do_request
+
+        expect(status).to eq(401)
+      end
+    end
+
+    context 'Missing parameters - 400' do
+      example 'CREATE : Returns 400 status code' do
+        explanation <<~DESC
+          Returns 400 status code in case of missing parameters
+        DESC
+
+        do_request
+
+        expect(status).to eq(400)
+      end
+    end
+
+    context 'Invalid parameters - 422' do
+      let(:raw_post) do
+        { data: build(:invalid_group_params) }.to_json
+      end
+
+      example 'CREATE : Returns 422 status code' do
+        explanation <<~DESC
+          Returns 422 status code in case of invalid parameters
+        DESC
+
+        do_request
+
+        expect(status).to eq(422)
+      end
+    end
+
+    context 'Access denied - 403' do
+      let(:student) { create(:student, :group_member) }
+
+      example 'CREATE : Returns 403 status code' do
+        explanation <<~DESC
+          Returns 403 status code in case in user has no access to action
+        DESC
+
+        do_request
+
+        expect(status).to eq(403)
+      end
+    end
+  end
+
+  put 'api/v1/group' do
+    context 'Authorized - 200' do
+      with_options scope: %i[data attributes] do
+        parameter :title, 'Human readable identity)', requred: true
+        parameter :number, 'Main group identity', requred: true
+      end
+
+      let(:raw_post) { { data: build(:group_params) }.to_json }
+
+      example 'UPDATE : Updates group information' do
+        explanation <<~DESC
+          Update and return updated group
+        DESC
+
+        do_request
+
+        expected_body = GroupSerializer
+                        .new(student.reload.group)
+                        .serialized_json
+                        .to_s
+
+        expect(status).to eq(200)
+        expect(response_body).to eq(expected_body)
+      end
+    end
+
+    context 'Unauthorized - 401' do
+      let(:authorization) { nil }
+
+      example 'UPDATE : Returns 401 status code' do
+        explanation <<~DESC
+          Returns 401 status code in case of missing or invalid access token
+        DESC
+
+        do_request
+
+        expect(status).to eq(401)
+      end
+    end
+
+    context 'Missing parameters - 400' do
+      example 'UPDATE : Returns 400 status code' do
+        explanation <<~DESC
+          Returns 400 status code in case of missing parameters
+        DESC
+
+        do_request
+
+        expect(status).to eq(400)
+      end
+    end
+
+    context 'Invalid parameters - 422' do
+      let(:raw_post) do
+        { data: build(:invalid_group_params) }.to_json
+      end
+
+      example 'UPDATE : Returns 422 status code' do
+        explanation <<~DESC
+          Returns 422 status code in case of invalid parameters
+        DESC
+
+        do_request
+
+        expect(status).to eq(422)
+      end
+    end
+
+    context 'Access denied - 403' do
+      let(:student) { create(:student, :group_member) }
+
+      example 'CREATE : Returns 403 status code' do
+        explanation <<~DESC
+          Returns 403 status code in case in user has no access to action
+        DESC
+
+        do_request
+
+        expect(status).to eq(403)
+      end
+    end
+  end
+
+  delete 'api/v1/group' do
+    context 'Authorized - 200' do
+      example "DELETE : Deletes user's group" do
+        explanation <<~DESC
+          Deletes group
+        DESC
+
+        do_request
+
+        expect(status).to eq(204)
+      end
+    end
+
+    context 'Unauthorized - 401' do
+      let(:authorization) { nil }
+
+      example 'DELETE : Returns 401 status code' do
+        explanation <<~DESC
+          Returns 401 status code in case of missing or invalid access token
+        DESC
+
+        do_request
+
+        expect(status).to eq(401)
+      end
+    end
+
+    context 'Access denied - 403' do
+      let(:student) { create(:student, :group_member) }
+
+      example 'CREATE : Returns 403 status code' do
+        explanation <<~DESC
+          Returns 403 status code in case in user has no access to action
+        DESC
+
+        do_request
+
+        expect(status).to eq(403)
+      end
+    end
+  end
+end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -7,4 +7,28 @@ FactoryBot.define do
 
     president
   end
+
+  factory :group_params, class: Hash do
+    initialize_with do
+      {
+        type: 'group',
+        attributes: {
+          title: Faker::Lorem.sentence(3),
+          number: Faker::Number.number(5)
+        }
+      }
+    end
+  end
+
+  factory :invalid_group_params, class: Hash do
+    initialize_with do
+      {
+        type: 'group',
+        attributes: {
+          title: nil,
+          number: nil
+        }
+      }
+    end
+  end
 end

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -26,6 +26,12 @@ FactoryBot.define do
       end
     end
 
+    trait :group_supervisor do
+      after(:create) do |student, _|
+        student.supervised_group = create(:group, president: student, students: [student])
+      end
+    end
+
     factory :president, traits: [:president]
   end
 

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -45,4 +45,48 @@ RSpec.describe Student, type: :model do
       end
     end
   end
+
+  describe '#any_group?' do
+    subject { student.any_group? }
+
+    context 'no groups' do
+      let(:student) { create(:student) }
+
+      it { expect(subject).to be false }
+    end
+
+    context 'has supervised group' do
+      let(:student) { create(:student, :group_supervisor) }
+
+      it { expect(subject).to be true }
+    end
+
+    context 'has group' do
+      let(:student) { create(:student, :group_member) }
+
+      it { expect(subject).to be true }
+    end
+  end
+
+  describe '#group_owner?' do
+    subject { student.group_owner? }
+
+    context 'no groups' do
+      let(:student) { create(:student) }
+
+      it { expect(subject).to be false }
+    end
+
+    context 'has supervised group' do
+      let(:student) { create(:student, :group_supervisor) }
+
+      it { expect(subject).to be true }
+    end
+
+    context 'has group' do
+      let(:student) { create(:student, :group_member) }
+
+      it { expect(subject).to be false }
+    end
+  end
 end

--- a/spec/requests/api/v1/groups_spec.rb
+++ b/spec/requests/api/v1/groups_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Group management', type: :request do
+  include_context 'shared auth'
+
+  let(:group_url) { '/api/v1/group' }
+
+  let(:group_params) { build(:group_params) }
+
+  let(:request_params) { { data: group_params } }
+  let(:invalid_request_params) { { data: build(:invalid_group_params) } }
+
+  describe 'GET #show' do
+    let!(:student) { create(:student, :group_member, user: user) }
+
+    before(:each) { get group_url, headers: auth_header }
+
+    it 'responds with a 200 status' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    include_examples 'json:api examples',
+                     %w[id type attributes relationships],
+                     %w[title number created_at updated_at],
+                     %w[students]
+  end
+
+  describe 'POST #create' do
+    subject { post group_url, params: request_params, headers: auth_header }
+
+    context 'student with group' do
+      context 'simple group member' do
+        let!(:student) { create(:student, :group_member, user: user) }
+
+        before(:each) { subject }
+
+        it 'responds with 403 - forbidden' do
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+
+      context 'group owner' do
+        let!(:student) { create(:student, :group_supervisor, user: user) }
+
+        before(:each) { subject }
+
+        it 'responds with 403 - forbidden' do
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+    end
+
+    context 'student with no group' do
+      let!(:student) { create(:student, user: user) }
+
+      before(:each) { subject }
+
+      context 'valid params' do
+        it 'responds with a 201 status' do
+          expect(response).to have_http_status(:created)
+        end
+
+        include_examples 'json:api examples',
+                         %w[id type attributes relationships],
+                         %w[title number created_at updated_at],
+                         %w[students]
+      end
+
+      include_examples 'request errors examples'
+    end
+  end
+
+  describe 'PUT #update' do
+    subject { put group_url, params: request_params, headers: auth_header }
+
+    context 'simple group owner' do
+      let!(:student) { create(:student, :group_member, user: user) }
+
+      before(:each) { subject }
+
+      it 'responds with 403 - forbidden' do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'student with no group' do
+      let!(:student) { create(:student, user: user) }
+
+      before(:each) { subject }
+
+      it 'responds with 403 - forbidden' do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'group owner' do
+      let!(:student) { create(:student, :group_supervisor, user: user) }
+
+      before(:each) { subject }
+
+      it 'responds with a 200 status' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      include_examples 'json:api examples',
+                       %w[id type attributes relationships],
+                       %w[title number created_at updated_at],
+                       %w[students]
+
+      it 'updates a supervised group information' do
+        actual_group_title = student.supervised_group.reload.title
+        expected_group_title = group_params[:attributes][:title]
+
+        expect(actual_group_title).to eq(expected_group_title)
+      end
+
+      include_examples 'request errors examples'
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    let!(:student) { create(:student, :group_supervisor, user: user) }
+
+    it 'responds with a 204 status' do
+      delete group_url, headers: auth_header
+
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it 'deletes group' do
+      expect { delete group_url, headers: auth_header }.to change(Group, :count).by(-1)
+    end
+  end
+end

--- a/spec/routing/api/v1/groups_routing_spec.rb
+++ b/spec/routing/api/v1/groups_routing_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+#
+#   api_v1_group  GET    /api/v1/group(.:format)  api/v1/groups#show    {:format => "json"}
+#                 PATCH  /api/v1/group(.:format)  api/v1/groups#update  {:format => "json"}
+#                 PUT    /api/v1/group(.:format)  api/v1/groups#update  {:format => "json"}
+#                 DELETE /api/v1/group(.:format)  api/v1/groups#destroy {:format => "json"}
+#                 POST   /api/v1/group(.:format)  api/v1/groups#create  {:format => "json"}
+#
+describe Api::V1::GroupsController, 'routing' do
+  it 'routes to #show' do
+    expect(get('api/v1/group')).to route_to('api/v1/groups#show', format: 'json')
+  end
+
+  it 'routes to #create' do
+    expect(post('api/v1/group')).to route_to('api/v1/groups#create', format: 'json')
+  end
+
+  it 'routes to #update' do
+    expect(patch('api/v1/group')).to route_to('api/v1/groups#update', format: 'json')
+  end
+
+  it 'routes to #update' do
+    expect(put('api/v1/group')).to route_to('api/v1/groups#update', format: 'json')
+  end
+
+  it 'routes to #destroy' do
+    expect(delete('api/v1/group')).to route_to('api/v1/groups#destroy', format: 'json')
+  end
+end

--- a/spec/services/groups/creator_spec.rb
+++ b/spec/services/groups/creator_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe Groups::Creator do
+  subject { described_class.new.execute(owner, params) }
+
+  let(:params) { { number: '123', title: 'wat' } }
+
+  context 'when owner already has a group' do
+    let(:owner) { create(:president) }
+
+    it 'throws validation error' do
+      expect { subject }.to raise_error(ActiveRecord::RecordInvalid, 'student already has a group!')
+    end
+  end
+
+  context 'when owner has no group' do
+    let(:owner) { create(:student) }
+
+    it { expect { subject }.to change(Group, :count).by 1 }
+
+    it { expect(subject).to be_an Group }
+
+    it { expect(subject.number).to eq(params[:number]) }
+
+    it { expect(subject.title).to eq(params[:title]) }
+
+    it 'appoints an owner as group president' do
+      expect(subject.president).to eq(owner)
+    end
+
+    it 'adds owner as group member' do
+      expect(subject.students).to eq([owner])
+    end
+
+    context 'invalid title in params' do
+      let(:params) { { title: nil } }
+
+      it { expect { subject }.to raise_error(ActiveRecord::RecordInvalid) }
+    end
+
+    context 'invalid number in params' do
+      let(:params) { { number: nil } }
+
+      it { expect { subject }.to raise_error(ActiveRecord::RecordInvalid) }
+    end
+  end
+end

--- a/spec/support/auth_context.rb
+++ b/spec/support/auth_context.rb
@@ -1,0 +1,5 @@
+RSpec.shared_context 'shared auth' do
+  let(:user)        { create(:user) }
+  let(:token)       { create(:token, resource_owner_id: user.id) }
+  let(:auth_header) { { 'Authorization' => "Bearer #{token.token}" } }
+end

--- a/spec/support/json_api_shared_examples.rb
+++ b/spec/support/json_api_shared_examples.rb
@@ -1,0 +1,25 @@
+RSpec.shared_examples 'json:api examples' do |body, attributes, relationships|
+  it 'responds with root json-api keys' do
+    expect(body_as_json.keys).to match_array(%w[data])
+  end
+
+  it { expect(response.body).to look_like_json }
+
+  it 'responds with json-api format' do
+    actual_keys = body_as_json[:data].keys
+
+    expect(actual_keys).to match_array(body)
+  end
+
+  it 'responds with correct relationships' do
+    actual_keys = body_as_json[:data][:relationships].keys
+
+    expect(actual_keys).to match_array(relationships)
+  end
+
+  it 'returns correct data format' do
+    actual_keys = body_as_json[:data][:attributes].keys
+
+    expect(actual_keys).to match_array(attributes)
+  end
+end

--- a/spec/support/request_errors_shared_examples.rb
+++ b/spec/support/request_errors_shared_examples.rb
@@ -1,0 +1,19 @@
+RSpec.shared_examples 'request errors examples' do
+  context 'responds with a 400 status on request with empty params' do
+    let(:request_params) { nil }
+
+    it { expect(response).to have_http_status(:bad_request) }
+  end
+
+  context 'responds with a 422 status on request with not valid params' do
+    let(:request_params) { invalid_request_params }
+
+    it { expect(response).to have_http_status(:unprocessable_entity) }
+  end
+
+  context 'responds with a 401 status on not presented auth header' do
+    let(:auth_header) { nil }
+
+    it { expect(response).to have_http_status(:unauthorized) }
+  end
+end


### PR DESCRIPTION
Added basic user's group management.

A user can create a new group if he not a member of any group.
Every user has access to the group info and only a group owner has access to group management.
When a user creates a new group he becomes a group owner and group member.

`Groups::Creator` is used to create a new group and promotes a user as the group owner.
`Api::V1::GroupsController` is used to access/control user's group information.