### PR TITLE
Add N+1 query detection

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,9 +2,11 @@
 
 require 'simplecov'
 SimpleCov.start do
-  add_filter 'config/initializers/doorkeeper.rb'
   add_filter 'spec/support/helpers/stub_env.rb'
   add_filter 'spec/support/redis/redis_helpers.rb'
+  add_filter 'spec/support/bullet_context.rb'
+
+  add_filter 'config/initializers/doorkeeper.rb'
   add_filter 'config/initializers/sidekiq.rb'
   add_filter 'config/initializers/rack_attack.rb'
   add_filter 'config/initializers/rack_attack_logging.rb'
@@ -95,6 +97,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.alias_example_to :bulletify, bullet: true
 
   # WARNING!
   #

--- a/spec/requests/api/v1/events_spec.rb
+++ b/spec/requests/api/v1/events_spec.rb
@@ -21,9 +21,13 @@ RSpec.describe 'Events management', type: :request do
 
     let_it_be(:events) { create_list(:event, 5, creator: student) }
 
-    before(:each) { subject }
+    context 'N+1' do
+      bulletify { subject }
+    end
 
     context 'unsorted events collection' do
+      before(:each) { subject }
+
       it 'responds with a 200 status' do
         expect(response).to have_http_status(:ok)
       end

--- a/spec/requests/api/v1/group/invites_spec.rb
+++ b/spec/requests/api/v1/group/invites_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe 'Group invites management', type: :request do
 
     let(:endpoint) { base }
 
+    context 'N+1' do
+      bulletify { subject }
+    end
+
     context 'authorized' do
       before(:each) { subject }
 

--- a/spec/requests/api/v1/group/students_spec.rb
+++ b/spec/requests/api/v1/group/students_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe 'Students management', type: :request do
   describe 'GET #index' do
     let(:endpoint) { base }
 
+    context 'N+1' do
+      bulletify { subject }
+    end
+
     context 'authorized user' do
       it { expect(response).to have_http_status(:ok) }
 

--- a/spec/requests/api/v1/invites_spec.rb
+++ b/spec/requests/api/v1/invites_spec.rb
@@ -18,9 +18,13 @@ RSpec.describe 'Invites management', type: :request do
 
     let(:endpoint) { base }
 
-    before(:each) { subject }
+    context 'N+1' do
+      bulletify { subject }
+    end
 
     context 'unsorted invites collection' do
+      before(:each) { subject }
+
       it 'responds with a 200 status' do
         expect(response).to have_http_status(:ok)
       end

--- a/spec/support/bullet_context.rb
+++ b/spec/support/bullet_context.rb
@@ -1,0 +1,16 @@
+RSpec.shared_context 'bullet', bullet: true do
+  before(:each) do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.raise = true # raise an error if N+1 query occurs
+    Bullet.start_request
+  end
+
+  after(:each) do
+    Bullet.perform_out_of_channel_notifications if Bullet.notification?
+    Bullet.end_request
+    Bullet.enable = false
+    Bullet.bullet_logger = false
+    Bullet.raise = false
+  end
+end


### PR DESCRIPTION
File `bullet_context` contains context for tests that helps identifies
N+1 queries. This context is based on `bullet` logger, if the request contains
N+1 query bullet exception will be raised.