### PR TITLE
Closes #67: Add course binding to the event

### DIFF
--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    # Api::V1::CoursesController
+    #
+    #   [DESCRIPTION]
+    #
+    class CoursesController < ApplicationController
+      set_default_serializer CourseSerializer
+
+      before_action :authorize_edit!, only: %i[create update destroy]
+
+      # GET : api/v1/group/courses
+      #
+      # Get list of courses
+      #
+      def index
+        courses = filter_courses.eager_load(:lecturers)
+
+        render_json courses, status: :ok
+      end
+
+      # GET : api/v1/group/courses/{:id}
+      #
+      # Get course by id (information about course)
+      #
+      def show
+        course = filter_courses.find(params[:id])
+
+        render_json course, status: :ok
+      end
+
+      # POST : api/v1/group/courses
+      #
+      # Create new course
+      #
+      def create
+        course = current_group.courses.create!(course_params)
+
+        render_json course, status: :created
+      end
+
+      # PATCH/PUT : api/v1/group/courses/{:id}
+      #
+      # Update course(information about course)
+      #
+      def update
+        course = filter_courses.find(params[:id])
+
+        course.update!(course_params)
+
+        render_json course, status: :ok
+      end
+
+      # DELETE : api/v1/group/courses/{:id}
+      #
+      # Delete course
+      #
+      def destroy
+        course = filter_courses.find(params[:id])
+
+        course.destroy!
+
+        head :no_content
+      end
+
+      private
+
+      def authorize_edit!
+        return if current_student.group_owner?
+
+        raise Elplano::Errors::AuthError, 'Edit not allowed'
+      end
+
+      def filter_courses
+        current_group.courses
+      end
+
+      def course_params
+        restify_param(:course)
+          .require(:course)
+          .permit(:title, lecturer_ids: [])
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -71,6 +71,7 @@ module Api
           .permit(
             :title, :description, :status,
             :start_at, :end_at, :timezone,
+            :course_id,
             recurrence: []
           )
       end

--- a/app/controllers/api/v1/lecturers_controller.rb
+++ b/app/controllers/api/v1/lecturers_controller.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    # Api::V1::LecturersController
+    #
+    #   [DESCRIPTION]
+    #
+    class LecturersController < ApplicationController
+      set_default_serializer LecturerSerializer
+
+      before_action :authorize_edit!, only: %i[create update destroy]
+
+      # GET : api/v1/group/lecturers
+      #
+      # Get list of lecturers
+      #
+      def index
+        lecturers = filter_lecturers.eager_load(:courses)
+
+        render_json lecturers, status: :ok
+      end
+
+      # GET : api/v1/group/lecturers/{:id}
+      #
+      # Get lecturer by id (information about lecturer)
+      #
+      def show
+        lecturer = filter_lecturers.find(params[:id])
+
+        render_json lecturer, status: :ok
+      end
+
+      # POST : api/v1/group/lecturers
+      #
+      # Create new lecturer
+      #
+      def create
+        lecturer = current_group.lecturers.create!(lecturer_params)
+
+        render_json lecturer, status: :created
+      end
+
+      # PATCH/PUT : api/v1/group/lecturers/{:id}
+      #
+      # Update lecturer(information about lecturer)
+      #
+      def update
+        lecturer = filter_lecturers.find(params[:id])
+
+        lecturer.update!(lecturer_params)
+
+        render_json lecturer, status: :ok
+      end
+
+      # DELETE : api/v1/group/lecturers/{:id}
+      #
+      # Delete lecturer
+      #
+      def destroy
+        lecturer = filter_lecturers.find(params[:id])
+
+        lecturer.destroy!
+
+        head :no_content
+      end
+
+      private
+
+      def filter_lecturers
+        current_group.lecturers
+      end
+
+      def authorize_edit!
+        return if current_student.group_owner?
+
+        raise Elplano::Errors::AuthError, 'Edit not allowed'
+      end
+
+      def lecturer_params
+        restify_param(:lecturer)
+          .require(:lecturer)
+          .permit(:first_name, :last_name, :patronymic, course_ids: [])
+      end
+    end
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Course
+#
+#   [DESCRIPTION]
+#
+class Course < ApplicationRecord
+  belongs_to :group
+
+  has_many :lectures, dependent: :delete_all
+
+  has_many :lecturers, through: :lectures
+
+  has_many :events, dependent: :nullify
+
+  validates :title, :group, presence: true
+
+  validates :title, length: { maximum: 200 }
+
+  validates :title, uniqueness: { case_sensitive: false, scope: %i[group_id] }
+
+  before_validation -> { title&.downcase! }
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -82,6 +82,8 @@ class Event < ApplicationRecord
 
   belongs_to :creator, class_name: 'Student', inverse_of: :created_events
 
+  belongs_to :course, optional: true
+
   validates :creator, :start_at, :timezone, presence: true
   validates :title, presence: true, length: { in: 3..250 }
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -13,6 +13,10 @@ class Group < ApplicationRecord
 
   has_many :invites, dependent: :destroy
 
+  has_many :lecturers, dependent: :destroy
+
+  has_many :courses, dependent: :destroy
+
   validates :number, presence: true, length: { maximum: 25 }
   validates :title, length: { maximum: 200 }
 end

--- a/app/models/lecture.rb
+++ b/app/models/lecture.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Lecture
+#
+#   [DESCRIPTION]
+#
+class Lecture < ApplicationRecord
+  belongs_to :lecturer
+  belongs_to :course
+end

--- a/app/models/lecturer.rb
+++ b/app/models/lecturer.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Lecturer
+#
+#   [DESCRIPTION]
+#
+class Lecturer < ApplicationRecord
+  belongs_to :group
+
+  has_many :lectures, dependent: :delete_all
+
+  has_many :courses, through: :lectures
+
+  validates :first_name, :last_name, :patronymic, presence: true, length: { maximum: 40 }
+
+  validates :group, presence: true
+
+  validates :group_id,
+            uniqueness: {
+              case_sensitive: false,
+              scope: %i[first_name last_name patronymic]
+            }
+
+  before_validation :downcase_names!
+
+  def downcase_names!
+    first_name&.downcase!
+    last_name&.downcase!
+    patronymic&.downcase!
+  end
+end

--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# CourseSerializer
+#
+#   [DESCRIPTION]
+#
+class CourseSerializer
+  include FastJsonapi::ObjectSerializer
+
+  set_type :course
+
+  attributes :created_at, :updated_at
+
+  attribute :title do |object|
+    object.title.titleize
+  end
+
+  has_many :lecturers, serializer: LecturerSerializer
+end

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -15,5 +15,7 @@ class EventSerializer
   belongs_to :creator,
              record_type: :student,
              serializer: StudentSerializer
+
+  belongs_to :course, serializer: CourseSerializer
 end
 

--- a/app/serializers/lecturer_serializer.rb
+++ b/app/serializers/lecturer_serializer.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# LecturerSerializer
+#
+#   [DESCRIPTION]
+#
+class LecturerSerializer
+  include FastJsonapi::ObjectSerializer
+
+  set_type :lecturer
+
+  attributes :created_at, :updated_at
+
+  attribute :first_name do |object|
+    object.first_name.titleize
+  end
+
+  attribute :last_name do |object|
+    object.last_name.titleize
+  end
+
+  attribute :patronymic do |object|
+    object.patronymic.titleize
+  end
+
+  has_many :courses, serializer: CourseSerializer
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,9 @@ Rails.application.routes.draw do
 
   namespace :api, defaults: { format: 'json' } do
     namespace :v1 do
+      # (see CoursesController)
+      resources :courses, except: %i[new edit]
+
       # (see EventsController)
       resources :events, except: %i[new edit]
 
@@ -39,6 +42,9 @@ Rails.application.routes.draw do
 
       # (see InvitesController)
       resources :invites, only: %i[index show update], param: :token
+
+      # (see LecturersController)
+      resources :lecturers, except: %i[new edit]
 
       # (see StudentsController)
       resource :student, only: %i[show update]

--- a/db/migrate/20190225120111_create_lecturers.rb
+++ b/db/migrate/20190225120111_create_lecturers.rb
@@ -1,0 +1,18 @@
+class CreateLecturers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :lecturers do |t|
+      t.string :first_name,   null: false, limit: 40
+      t.string :last_name,    null: false, limit: 40
+      t.string :patronymic,   null: false, limit: 40
+
+      t.references :group,null: false, foreign_key: true, index: true
+
+      t.timestamps
+    end
+
+    add_index :lecturers,
+              %i[group_id first_name last_name patronymic],
+              unique: :true,
+              name: 'index_lecturers_on_full_name_and_group'
+  end
+end

--- a/db/migrate/20190225131837_create_courses.rb
+++ b/db/migrate/20190225131837_create_courses.rb
@@ -1,0 +1,13 @@
+class CreateCourses < ActiveRecord::Migration[5.2]
+  def change
+    create_table :courses do |t|
+      t.string :title, null: false, limit: 200
+
+      t.references :group,null: false, foreign_key: true, index: true
+
+      t.timestamps
+    end
+
+    add_index :courses, %i[group_id title], unique: true
+  end
+end

--- a/db/migrate/20190225135808_create_lectures.rb
+++ b/db/migrate/20190225135808_create_lectures.rb
@@ -1,0 +1,12 @@
+class CreateLectures < ActiveRecord::Migration[5.2]
+  def change
+    create_table :lectures do |t|
+      t.references :lecturer, foreign_key: true, index: true
+      t.references :course, foreign_key: true, index: true
+
+      t.timestamps
+    end
+
+    add_index :lectures, %i[lecturer_id course_id], unique: true
+  end
+end

--- a/db/migrate/20190226124850_add_course_reference_to_event.rb
+++ b/db/migrate/20190226124850_add_course_reference_to_event.rb
@@ -1,0 +1,5 @@
+class AddCourseReferenceToEvent < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :events, :course, foreign_key: true, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_18_093324) do
+ActiveRecord::Schema.define(version: 2019_02_26_124850) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "courses", force: :cascade do |t|
+    t.string "title", limit: 200, null: false
+    t.bigint "group_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id", "title"], name: "index_courses_on_group_id_and_title", unique: true
+    t.index ["group_id"], name: "index_courses_on_group_id"
+  end
 
   create_table "events", force: :cascade do |t|
     t.string "title", null: false
@@ -26,6 +35,8 @@ ActiveRecord::Schema.define(version: 2019_02_18_093324) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "status", default: "confirmed", null: false
+    t.bigint "course_id"
+    t.index ["course_id"], name: "index_events_on_course_id"
     t.index ["creator_id"], name: "index_events_on_creator_id"
   end
 
@@ -53,6 +64,27 @@ ActiveRecord::Schema.define(version: 2019_02_18_093324) do
     t.index ["invitation_token"], name: "index_invites_on_invitation_token", unique: true
     t.index ["recipient_id"], name: "index_invites_on_recipient_id"
     t.index ["sender_id"], name: "index_invites_on_sender_id"
+  end
+
+  create_table "lecturers", force: :cascade do |t|
+    t.string "first_name", limit: 40, null: false
+    t.string "last_name", limit: 40, null: false
+    t.string "patronymic", limit: 40, null: false
+    t.bigint "group_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id", "first_name", "last_name", "patronymic"], name: "index_lecturers_on_full_name_and_group", unique: true
+    t.index ["group_id"], name: "index_lecturers_on_group_id"
+  end
+
+  create_table "lectures", force: :cascade do |t|
+    t.bigint "lecturer_id"
+    t.bigint "course_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["course_id"], name: "index_lectures_on_course_id"
+    t.index ["lecturer_id", "course_id"], name: "index_lectures_on_lecturer_id_and_course_id", unique: true
+    t.index ["lecturer_id"], name: "index_lectures_on_lecturer_id"
   end
 
   create_table "oauth_access_grants", force: :cascade do |t|
@@ -154,11 +186,16 @@ ActiveRecord::Schema.define(version: 2019_02_18_093324) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  add_foreign_key "courses", "groups"
+  add_foreign_key "events", "courses"
   add_foreign_key "events", "students", column: "creator_id"
   add_foreign_key "groups", "students", column: "president_id"
   add_foreign_key "invites", "groups"
   add_foreign_key "invites", "students", column: "recipient_id"
   add_foreign_key "invites", "students", column: "sender_id"
+  add_foreign_key "lecturers", "groups"
+  add_foreign_key "lectures", "courses"
+  add_foreign_key "lectures", "lecturers"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_grants", "users", column: "resource_owner_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"

--- a/doc/api/courses/create_:_create_new_course.json
+++ b/doc/api/courses/create_:_create_new_course.json
@@ -1,0 +1,66 @@
+{
+  "resource": "Courses",
+  "resource_explanation": "El Plano courses API.\n\nCourse attributes :\n\n - `title` - Represents course name(human readable identity).\n - timestamps\n\n Also, includes reference to the course lecturer.\n",
+  "http_method": "POST",
+  "route": "api/v1/courses",
+  "description": "CREATE : Create new course",
+  "explanation": "Create and return created course.\n",
+  "parameters": [
+    {
+      "scope": [
+        "dta",
+        "attributes"
+      ],
+      "requred": true,
+      "name": "title",
+      "description": "Course title(human readable identity)"
+    },
+    {
+      "scope": [
+        "dta",
+        "attributes"
+      ],
+      "name": "lecturers",
+      "description": "Lecturers of the course. Included in \"relationships\" category"
+    }
+  ],
+  "response_fields": [
+
+  ],
+  "requests": [
+    {
+      "request_method": "POST",
+      "request_path": "api/v1/courses",
+      "request_body": "{\"data\":{\"type\":\"course\",\"attributes\":{\"title\":\"Associate Degree in Medicine\"},\"relationships\":{\"lecturers\":{\"data\":[{\"id\":3,\"type\":\"lecturer\"}]}}}}",
+      "request_headers": {
+        "Accept": "application/vnd.api+json",
+        "Content-Type": "application/vnd.api+json",
+        "Authorization": "Bearer 0e401cf5a413d83fbfe6b62b928295434d9e5363ae5b648feed92a2849401dd7",
+        "Host": "example.org",
+        "Cookie": ""
+      },
+      "request_query_parameters": {
+      },
+      "request_content_type": "application/vnd.api+json",
+      "response_status": 201,
+      "response_status_text": "Created",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"3\",\n    \"type\": \"course\",\n    \"attributes\": {\n      \"created_at\": \"2019-02-27T06:43:20.617Z\",\n      \"updated_at\": \"2019-02-27T06:43:20.617Z\",\n      \"title\": \"Associate Degree In Medicine\"\n    },\n    \"relationships\": {\n      \"lecturers\": {\n        \"data\": [\n          {\n            \"id\": \"3\",\n            \"type\": \"lecturer\"\n          }\n        ]\n      }\n    }\n  }\n}",
+      "response_headers": {
+        "Page-Title": "El+Plano",
+        "X-Frame-Options": "DENY",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "Cache-Control": "max-age=0, private, must-revalidate, no-store",
+        "Pragma": "no-cache",
+        "Content-Type": "application/json; charset=utf-8",
+        "ETag": "W/\"31a7e659ead27d464b7ac5e6138b250a\"",
+        "X-Request-Id": "57e8c304-df25-4583-8d2d-df2a1b84dc81",
+        "X-Runtime": "0.016733",
+        "Vary": "Origin",
+        "Content-Length": "239"
+      },
+      "response_content_type": "application/json; charset=utf-8",
+      "curl": "curl \"http://localhost:3000/api/v1/courses\" -d '{\"data\":{\"type\":\"course\",\"attributes\":{\"title\":\"Associate Degree in Medicine\"},\"relationships\":{\"lecturers\":{\"data\":[{\"id\":3,\"type\":\"lecturer\"}]}}}}' -X POST \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 0e401cf5a413d83fbfe6b62b928295434d9e5363ae5b648feed92a2849401dd7\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+    }
+  ]
+}

--- a/doc/api/courses/delete_:_delete_selected_course.json
+++ b/doc/api/courses/delete_:_delete_selected_course.json
@@ -1,0 +1,47 @@
+{
+  "resource": "Courses",
+  "resource_explanation": "El Plano courses API.\n\nCourse attributes :\n\n - `title` - Represents course name(human readable identity).\n - timestamps\n\n Also, includes reference to the course lecturer.\n",
+  "http_method": "DELETE",
+  "route": "api/v1/courses/:id",
+  "description": "DELETE : Delete selected course",
+  "explanation": "Delete course.\n",
+  "parameters": [
+
+  ],
+  "response_fields": [
+
+  ],
+  "requests": [
+    {
+      "request_method": "DELETE",
+      "request_path": "api/v1/courses/5",
+      "request_body": null,
+      "request_headers": {
+        "Accept": "application/vnd.api+json",
+        "Content-Type": "application/vnd.api+json",
+        "Authorization": "Bearer 2a79a8abb38af2b183c8e3ab435b3b41438ae6c6f069cffad7b51e54cc8e96ed",
+        "Host": "example.org",
+        "Cookie": ""
+      },
+      "request_query_parameters": {
+      },
+      "request_content_type": "application/vnd.api+json",
+      "response_status": 204,
+      "response_status_text": "No Content",
+      "response_body": null,
+      "response_headers": {
+        "Page-Title": "El+Plano",
+        "X-Frame-Options": "DENY",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "Cache-Control": "max-age=0, private, must-revalidate, no-store",
+        "Pragma": "no-cache",
+        "X-Request-Id": "28b52cbd-27a3-4ea2-941f-89f4e34ba7b8",
+        "X-Runtime": "0.014474",
+        "Vary": "Origin"
+      },
+      "response_content_type": null,
+      "curl": "curl \"http://localhost:3000/api/v1/courses/5\" -d '' -X DELETE \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 2a79a8abb38af2b183c8e3ab435b3b41438ae6c6f069cffad7b51e54cc8e96ed\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+    }
+  ]
+}

--- a/doc/api/courses/index_:_retrieve_courses_created_by_authenticated_user.json
+++ b/doc/api/courses/index_:_retrieve_courses_created_by_authenticated_user.json
@@ -1,0 +1,50 @@
+{
+  "resource": "Courses",
+  "resource_explanation": "El Plano courses API.\n\nCourse attributes :\n\n - `title` - Represents course name(human readable identity).\n - timestamps\n\n Also, includes reference to the course lecturer.\n",
+  "http_method": "GET",
+  "route": "api/v1/courses",
+  "description": "INDEX : Retrieve courses created by authenticated user",
+  "explanation": "Return list of available courses.\n",
+  "parameters": [
+
+  ],
+  "response_fields": [
+
+  ],
+  "requests": [
+    {
+      "request_method": "GET",
+      "request_path": "api/v1/courses",
+      "request_body": null,
+      "request_headers": {
+        "Accept": "application/vnd.api+json",
+        "Content-Type": "application/vnd.api+json",
+        "Authorization": "Bearer a16a07694100ffe983d97c893a0c3cb82f44f747b7bea701f8e2ccf3e22744d3",
+        "Host": "example.org",
+        "Cookie": ""
+      },
+      "request_query_parameters": {
+      },
+      "request_content_type": "application/vnd.api+json",
+      "response_status": 200,
+      "response_status_text": "OK",
+      "response_body": "{\n  \"data\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"course\",\n      \"attributes\": {\n        \"created_at\": \"2019-02-27T06:43:20.431Z\",\n        \"updated_at\": \"2019-02-27T06:43:20.431Z\",\n        \"title\": \"Neque Unde.\"\n      },\n      \"relationships\": {\n        \"lecturers\": {\n          \"data\": [\n            {\n              \"id\": \"1\",\n              \"type\": \"lecturer\"\n            }\n          ]\n        }\n      }\n    }\n  ]\n}",
+      "response_headers": {
+        "Page-Title": "El+Plano",
+        "X-Frame-Options": "DENY",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "Cache-Control": "max-age=0, private, must-revalidate, no-store",
+        "Pragma": "no-cache",
+        "Content-Type": "application/json; charset=utf-8",
+        "ETag": "W/\"e22c6b435c30962eb498c6c7987ab6b5\"",
+        "X-Request-Id": "7ef7e007-e613-4e98-80a5-3f7f1b187e9e",
+        "X-Runtime": "0.031974",
+        "Vary": "Origin",
+        "Content-Length": "224"
+      },
+      "response_content_type": "application/json; charset=utf-8",
+      "curl": "curl -g \"http://localhost:3000/api/v1/courses\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer a16a07694100ffe983d97c893a0c3cb82f44f747b7bea701f8e2ccf3e22744d3\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+    }
+  ]
+}

--- a/doc/api/courses/show_:_retrieve_information_about_requested_course.json
+++ b/doc/api/courses/show_:_retrieve_information_about_requested_course.json
@@ -1,0 +1,50 @@
+{
+  "resource": "Courses",
+  "resource_explanation": "El Plano courses API.\n\nCourse attributes :\n\n - `title` - Represents course name(human readable identity).\n - timestamps\n\n Also, includes reference to the course lecturer.\n",
+  "http_method": "GET",
+  "route": "api/v1/courses/:id",
+  "description": "SHOW : Retrieve information about requested course",
+  "explanation": "Return single instance of the course.\n",
+  "parameters": [
+
+  ],
+  "response_fields": [
+
+  ],
+  "requests": [
+    {
+      "request_method": "GET",
+      "request_path": "api/v1/courses/2",
+      "request_body": null,
+      "request_headers": {
+        "Accept": "application/vnd.api+json",
+        "Content-Type": "application/vnd.api+json",
+        "Authorization": "Bearer 4e0bae71e64079080dda97bc6bee84ca7e52bca4d2b185afe255502b1a151b04",
+        "Host": "example.org",
+        "Cookie": ""
+      },
+      "request_query_parameters": {
+      },
+      "request_content_type": "application/vnd.api+json",
+      "response_status": 200,
+      "response_status_text": "OK",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"2\",\n    \"type\": \"course\",\n    \"attributes\": {\n      \"created_at\": \"2019-02-27T06:43:20.555Z\",\n      \"updated_at\": \"2019-02-27T06:43:20.555Z\",\n      \"title\": \"Quos Similique.\"\n    },\n    \"relationships\": {\n      \"lecturers\": {\n        \"data\": [\n          {\n            \"id\": \"2\",\n            \"type\": \"lecturer\"\n          }\n        ]\n      }\n    }\n  }\n}",
+      "response_headers": {
+        "Page-Title": "El+Plano",
+        "X-Frame-Options": "DENY",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "Cache-Control": "max-age=0, private, must-revalidate, no-store",
+        "Pragma": "no-cache",
+        "Content-Type": "application/json; charset=utf-8",
+        "ETag": "W/\"27821d1c6f89057eb14f203956dc0752\"",
+        "X-Request-Id": "0cba2428-cae6-4d42-b7ba-bd76c0b74da4",
+        "X-Runtime": "0.008391",
+        "Vary": "Origin",
+        "Content-Length": "226"
+      },
+      "response_content_type": "application/json; charset=utf-8",
+      "curl": "curl -g \"http://localhost:3000/api/v1/courses/2\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 4e0bae71e64079080dda97bc6bee84ca7e52bca4d2b185afe255502b1a151b04\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+    }
+  ]
+}

--- a/doc/api/courses/update_:_update_selected_course_information.json
+++ b/doc/api/courses/update_:_update_selected_course_information.json
@@ -1,0 +1,66 @@
+{
+  "resource": "Courses",
+  "resource_explanation": "El Plano courses API.\n\nCourse attributes :\n\n - `title` - Represents course name(human readable identity).\n - timestamps\n\n Also, includes reference to the course lecturer.\n",
+  "http_method": "PUT",
+  "route": "api/v1/courses/:id",
+  "description": "UPDATE : Update selected course information",
+  "explanation": "Update and return updated course.\n",
+  "parameters": [
+    {
+      "scope": [
+        "data",
+        "attributes"
+      ],
+      "requred": true,
+      "name": "title",
+      "description": "Course title(human readable identity)"
+    },
+    {
+      "scope": [
+        "data",
+        "attributes"
+      ],
+      "name": "lecturers",
+      "description": "Lecturers of the course. Included in \"relationships\" category"
+    }
+  ],
+  "response_fields": [
+
+  ],
+  "requests": [
+    {
+      "request_method": "PUT",
+      "request_path": "api/v1/courses/4",
+      "request_body": "{\"data\":{\"type\":\"course\",\"attributes\":{\"title\":\"Master of Arts\"},\"relationships\":{\"lecturers\":{\"data\":[{\"id\":5,\"type\":\"lecturer\"}]}}}}",
+      "request_headers": {
+        "Accept": "application/vnd.api+json",
+        "Content-Type": "application/vnd.api+json",
+        "Authorization": "Bearer d376be1b3d6ee36deae555cb4935d491d89392c7781503a3fd3b06cc6e099e0c",
+        "Host": "example.org",
+        "Cookie": ""
+      },
+      "request_query_parameters": {
+      },
+      "request_content_type": "application/vnd.api+json",
+      "response_status": 200,
+      "response_status_text": "OK",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"4\",\n    \"type\": \"course\",\n    \"attributes\": {\n      \"created_at\": \"2019-02-27T06:43:20.644Z\",\n      \"updated_at\": \"2019-02-27T06:43:20.674Z\",\n      \"title\": \"Master Of Arts\"\n    },\n    \"relationships\": {\n      \"lecturers\": {\n        \"data\": [\n          {\n            \"id\": \"5\",\n            \"type\": \"lecturer\"\n          }\n        ]\n      }\n    }\n  }\n}",
+      "response_headers": {
+        "Page-Title": "El+Plano",
+        "X-Frame-Options": "DENY",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "Cache-Control": "max-age=0, private, must-revalidate, no-store",
+        "Pragma": "no-cache",
+        "Content-Type": "application/json; charset=utf-8",
+        "ETag": "W/\"1ce3350980e430610b26f8b0ba38bbae\"",
+        "X-Request-Id": "8191583f-2a12-4639-8ad5-de29bbf44a3c",
+        "X-Runtime": "0.015154",
+        "Vary": "Origin",
+        "Content-Length": "225"
+      },
+      "response_content_type": "application/json; charset=utf-8",
+      "curl": "curl \"http://localhost:3000/api/v1/courses/4\" -d '{\"data\":{\"type\":\"course\",\"attributes\":{\"title\":\"Master of Arts\"},\"relationships\":{\"lecturers\":{\"data\":[{\"id\":5,\"type\":\"lecturer\"}]}}}}' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer d376be1b3d6ee36deae555cb4935d491d89392c7781503a3fd3b06cc6e099e0c\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+    }
+  ]
+}

--- a/doc/api/events/create_:_creates_new_event.json
+++ b/doc/api/events/create_:_creates_new_event.json
@@ -1,6 +1,6 @@
 {
   "resource": "Events",
-  "resource_explanation": "El Plano events API.\n\nEvent attributes :\n\n - `title` - Represents event name.\n - `description` - Represents event detailed description.\n - `status` - Represents event current status.\n   - `confirmed` - The event is confirmed. This is the default status.\n   - `tentative` - The event is tentatively confirmed.\n   - `cancelled` - The event is cancelled (deleted).\n\n - `recurrence` - Represents recurrence rules.\n - `timezone` - Timezone settings.\n - `start_at` - Represents when event starts.\n - `end_at` - Represents when event ends.\n - timestamps\n\n Also, includes reference to the event creator.\n",
+  "resource_explanation": "El Plano events API.\n\nEvent attributes :\n\n - `title` - Represents event name.\n - `description` - Represents event detailed description.\n - `status` - Represents event current status.\n   - `confirmed` - The event is confirmed. This is the default status.\n   - `tentative` - The event is tentatively confirmed.\n   - `cancelled` - The event is cancelled (deleted).\n\n - `recurrence` - Represents recurrence rules.\n - `timezone` - Timezone settings.\n - `start_at` - Represents when event starts.\n - `end_at` - Represents when event ends.\n - timestamps\n\n Also, includes reference to the event creator and attached course.\n",
   "http_method": "POST",
   "route": "api/v1/events",
   "description": "CREATE : Creates new event",
@@ -57,6 +57,14 @@
       "requred": true,
       "name": "timezone",
       "description": "Event timezone"
+    },
+    {
+      "scope": [
+        "dta",
+        "attributes"
+      ],
+      "name": "course",
+      "description": "The course to which the event is attached. Included in \"relationships\" category"
     }
   ],
   "response_fields": [
@@ -66,11 +74,11 @@
     {
       "request_method": "POST",
       "request_path": "api/v1/events",
-      "request_body": "{\"data\":{\"type\":\"event\",\"attributes\":{\"title\":\"Doloremque accusamus illum.\",\"description\":\"Sit impedit et. Nisi debitis commodi. Consequatur nesciunt quia. Iure accusamus dicta. Et odit dolor.\",\"status\":\"cancelled\",\"start_at\":\"2019-02-26\",\"end_at\":\"2019-02-28\",\"timezone\":\"Etc/GMT+12\",\"recurrence\":[\"EXDATE;VALUE=DATE:20150610\",\"RDATE;VALUE=DATE:20150609,20150611\",\"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"]}}}",
+      "request_body": "{\"data\":{\"type\":\"event\",\"attributes\":{\"title\":\"Laboriosam vel consequatur.\",\"description\":\"Qui qui quia. Vel qui sunt. Fuga quia consequatur. Voluptas consequatur et. Qui commodi praesentium.\",\"status\":\"cancelled\",\"start_at\":\"2019-02-26\",\"end_at\":\"2019-02-28\",\"timezone\":\"Etc/GMT+12\",\"recurrence\":[\"EXDATE;VALUE=DATE:20150610\",\"RDATE;VALUE=DATE:20150609,20150611\",\"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"]},\"relationships\":{\"course\":{\"data\":{\"id\":6,\"type\":\"course\"}}}}}",
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 29127aa68e445b0444e0682201b749a6b080660936d8be3bda275b658777b325",
+        "Authorization": "Bearer 403b40098d1559e394c05875d411991220347fdda24a95e54f808c96e946ffd8",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -79,7 +87,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 201,
       "response_status_text": "Created",
-      "response_body": "{\n  \"data\": {\n    \"id\": \"3\",\n    \"type\": \"event\",\n    \"attributes\": {\n      \"title\": \"Doloremque accusamus illum.\",\n      \"description\": \"Sit impedit et. Nisi debitis commodi. Consequatur nesciunt quia. Iure accusamus dicta. Et odit dolor.\",\n      \"status\": \"cancelled\",\n      \"recurrence\": [\n        \"EXDATE;VALUE=DATE:20150610\",\n        \"RDATE;VALUE=DATE:20150609,20150611\",\n        \"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"\n      ],\n      \"start_at\": \"2019-02-26T00:00:00.000Z\",\n      \"end_at\": \"2019-02-28T00:00:00.000Z\",\n      \"timezone\": \"Etc/GMT+12\",\n      \"created_at\": \"2019-02-27T06:08:48.419Z\",\n      \"updated_at\": \"2019-02-27T06:08:48.419Z\"\n    },\n    \"relationships\": {\n      \"creator\": {\n        \"data\": {\n          \"id\": \"6\",\n          \"type\": \"student\"\n        }\n      }\n    }\n  }\n}",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"3\",\n    \"type\": \"event\",\n    \"attributes\": {\n      \"title\": \"Laboriosam vel consequatur.\",\n      \"description\": \"Qui qui quia. Vel qui sunt. Fuga quia consequatur. Voluptas consequatur et. Qui commodi praesentium.\",\n      \"status\": \"cancelled\",\n      \"recurrence\": [\n        \"EXDATE;VALUE=DATE:20150610\",\n        \"RDATE;VALUE=DATE:20150609,20150611\",\n        \"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"\n      ],\n      \"start_at\": \"2019-02-26T00:00:00.000Z\",\n      \"end_at\": \"2019-02-28T00:00:00.000Z\",\n      \"timezone\": \"Etc/GMT+12\",\n      \"created_at\": \"2019-02-27T06:43:20.852Z\",\n      \"updated_at\": \"2019-02-27T06:43:20.852Z\"\n    },\n    \"relationships\": {\n      \"creator\": {\n        \"data\": {\n          \"id\": \"11\",\n          \"type\": \"student\"\n        }\n      },\n      \"course\": {\n        \"data\": {\n          \"id\": \"6\",\n          \"type\": \"course\"\n        }\n      }\n    }\n  }\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -88,14 +96,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/json; charset=utf-8",
-        "ETag": "W/\"152929e806d166191d5cb5c9622a7512\"",
-        "X-Request-Id": "e2cfbe74-f334-4d65-ac49-a9d39808d788",
-        "X-Runtime": "0.009205",
+        "ETag": "W/\"09f5d61cdf6eef10d3e51ecc12fa6a5b\"",
+        "X-Request-Id": "05f1f0bb-dfbc-4d52-aca5-6ffaabedd69a",
+        "X-Runtime": "0.011937",
         "Vary": "Origin",
-        "Content-Length": "595"
+        "Content-Length": "640"
       },
       "response_content_type": "application/json; charset=utf-8",
-      "curl": "curl \"http://localhost:3000/api/v1/events\" -d '{\"data\":{\"type\":\"event\",\"attributes\":{\"title\":\"Doloremque accusamus illum.\",\"description\":\"Sit impedit et. Nisi debitis commodi. Consequatur nesciunt quia. Iure accusamus dicta. Et odit dolor.\",\"status\":\"cancelled\",\"start_at\":\"2019-02-26\",\"end_at\":\"2019-02-28\",\"timezone\":\"Etc/GMT+12\",\"recurrence\":[\"EXDATE;VALUE=DATE:20150610\",\"RDATE;VALUE=DATE:20150609,20150611\",\"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"]}}}' -X POST \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 29127aa68e445b0444e0682201b749a6b080660936d8be3bda275b658777b325\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000/api/v1/events\" -d '{\"data\":{\"type\":\"event\",\"attributes\":{\"title\":\"Laboriosam vel consequatur.\",\"description\":\"Qui qui quia. Vel qui sunt. Fuga quia consequatur. Voluptas consequatur et. Qui commodi praesentium.\",\"status\":\"cancelled\",\"start_at\":\"2019-02-26\",\"end_at\":\"2019-02-28\",\"timezone\":\"Etc/GMT+12\",\"recurrence\":[\"EXDATE;VALUE=DATE:20150610\",\"RDATE;VALUE=DATE:20150609,20150611\",\"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"]},\"relationships\":{\"course\":{\"data\":{\"id\":6,\"type\":\"course\"}}}}}' -X POST \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 403b40098d1559e394c05875d411991220347fdda24a95e54f808c96e946ffd8\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/doc/api/events/delete_:_deletes_selected_event.json
+++ b/doc/api/events/delete_:_deletes_selected_event.json
@@ -1,6 +1,6 @@
 {
   "resource": "Events",
-  "resource_explanation": "El Plano events API.\n\nEvent attributes :\n\n - `title` - Represents event name.\n - `description` - Represents event detailed description.\n - `status` - Represents event current status.\n   - `confirmed` - The event is confirmed. This is the default status.\n   - `tentative` - The event is tentatively confirmed.\n   - `cancelled` - The event is cancelled (deleted).\n\n - `recurrence` - Represents recurrence rules.\n - `timezone` - Timezone settings.\n - `start_at` - Represents when event starts.\n - `end_at` - Represents when event ends.\n - timestamps\n\n Also, includes reference to the event creator.\n",
+  "resource_explanation": "El Plano events API.\n\nEvent attributes :\n\n - `title` - Represents event name.\n - `description` - Represents event detailed description.\n - `status` - Represents event current status.\n   - `confirmed` - The event is confirmed. This is the default status.\n   - `tentative` - The event is tentatively confirmed.\n   - `cancelled` - The event is cancelled (deleted).\n\n - `recurrence` - Represents recurrence rules.\n - `timezone` - Timezone settings.\n - `start_at` - Represents when event starts.\n - `end_at` - Represents when event ends.\n - timestamps\n\n Also, includes reference to the event creator and attached course.\n",
   "http_method": "DELETE",
   "route": "api/v1/events/:id",
   "description": "DELETE : Deletes selected event",
@@ -19,7 +19,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 0c2f5a05988796bb71df35e103ac910703532cb7aa9d46063c9cad06d8ca9041",
+        "Authorization": "Bearer e2a42093a30bc3da19f52cc6172fddbaa450c1c6a40348742e0381d0a94a3d29",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -36,12 +36,12 @@
         "X-Content-Type-Options": "nosniff",
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
-        "X-Request-Id": "72c84c94-95ac-4bef-b619-29d622fc1302",
-        "X-Runtime": "0.006138",
+        "X-Request-Id": "9cc0d61a-be6f-428d-a174-dec6cc6786ed",
+        "X-Runtime": "0.007689",
         "Vary": "Origin"
       },
       "response_content_type": null,
-      "curl": "curl \"http://localhost:3000/api/v1/events/5\" -d '' -X DELETE \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 0c2f5a05988796bb71df35e103ac910703532cb7aa9d46063c9cad06d8ca9041\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000/api/v1/events/5\" -d '' -X DELETE \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer e2a42093a30bc3da19f52cc6172fddbaa450c1c6a40348742e0381d0a94a3d29\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/doc/api/events/index_:_retrieve_events_created_by_authenticated_user.json
+++ b/doc/api/events/index_:_retrieve_events_created_by_authenticated_user.json
@@ -1,6 +1,6 @@
 {
   "resource": "Events",
-  "resource_explanation": "El Plano events API.\n\nEvent attributes :\n\n - `title` - Represents event name.\n - `description` - Represents event detailed description.\n - `status` - Represents event current status.\n   - `confirmed` - The event is confirmed. This is the default status.\n   - `tentative` - The event is tentatively confirmed.\n   - `cancelled` - The event is cancelled (deleted).\n\n - `recurrence` - Represents recurrence rules.\n - `timezone` - Timezone settings.\n - `start_at` - Represents when event starts.\n - `end_at` - Represents when event ends.\n - timestamps\n\n Also, includes reference to the event creator.\n",
+  "resource_explanation": "El Plano events API.\n\nEvent attributes :\n\n - `title` - Represents event name.\n - `description` - Represents event detailed description.\n - `status` - Represents event current status.\n   - `confirmed` - The event is confirmed. This is the default status.\n   - `tentative` - The event is tentatively confirmed.\n   - `cancelled` - The event is cancelled (deleted).\n\n - `recurrence` - Represents recurrence rules.\n - `timezone` - Timezone settings.\n - `start_at` - Represents when event starts.\n - `end_at` - Represents when event ends.\n - timestamps\n\n Also, includes reference to the event creator and attached course.\n",
   "http_method": "GET",
   "route": "api/v1/events",
   "description": "INDEX : Retrieve events created by authenticated user",
@@ -19,7 +19,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 9ba5fba94bf55a2e193501a1037ae647001b4693946eb965ad0b3f8efa0aa7e6",
+        "Authorization": "Bearer 70b7728875be2b3cdd177229caae24d054972e7e618f0cb133d748d5918b8933",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -28,7 +28,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 200,
       "response_status_text": "OK",
-      "response_body": "{\n  \"data\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"event\",\n      \"attributes\": {\n        \"title\": \"Perspiciatis explicabo quas assumenda.\",\n        \"description\": null,\n        \"status\": \"confirmed\",\n        \"recurrence\": [\n          \"EXDATE;VALUE=DATE:20150610\",\n          \"RDATE;VALUE=DATE:20150609,20150611\",\n          \"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"\n        ],\n        \"start_at\": \"2019-02-28T00:00:00.000Z\",\n        \"end_at\": null,\n        \"timezone\": \"Etc/GMT+12\",\n        \"created_at\": \"2019-02-27T06:08:48.305Z\",\n        \"updated_at\": \"2019-02-27T06:08:48.305Z\"\n      },\n      \"relationships\": {\n        \"creator\": {\n          \"data\": {\n            \"id\": \"2\",\n            \"type\": \"student\"\n          }\n        }\n      }\n    }\n  ]\n}",
+      "response_body": "{\n  \"data\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"event\",\n      \"attributes\": {\n        \"title\": \"Fuga sequi in numquam.\",\n        \"description\": null,\n        \"status\": \"confirmed\",\n        \"recurrence\": [\n          \"EXDATE;VALUE=DATE:20150610\",\n          \"RDATE;VALUE=DATE:20150609,20150611\",\n          \"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"\n        ],\n        \"start_at\": \"2019-02-28T00:00:00.000Z\",\n        \"end_at\": null,\n        \"timezone\": \"Etc/GMT+12\",\n        \"created_at\": \"2019-02-27T06:43:20.759Z\",\n        \"updated_at\": \"2019-02-27T06:43:20.759Z\"\n      },\n      \"relationships\": {\n        \"creator\": {\n          \"data\": {\n            \"id\": \"7\",\n            \"type\": \"student\"\n          }\n        },\n        \"course\": {\n          \"data\": null\n        }\n      }\n    }\n  ]\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -37,14 +37,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/json; charset=utf-8",
-        "ETag": "W/\"c0f5e635b89bbe9a8f0a22f307a623ca\"",
-        "X-Request-Id": "db59026e-ac24-4da6-806d-044b0924e821",
-        "X-Runtime": "0.022755",
+        "ETag": "W/\"bdc0539af4b6bef5b95d7605e51227c5\"",
+        "X-Request-Id": "5494d44a-4b6b-4888-87e8-f9124407c741",
+        "X-Runtime": "0.010399",
         "Vary": "Origin",
-        "Content-Length": "487"
+        "Content-Length": "494"
       },
       "response_content_type": "application/json; charset=utf-8",
-      "curl": "curl -g \"http://localhost:3000/api/v1/events\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 9ba5fba94bf55a2e193501a1037ae647001b4693946eb965ad0b3f8efa0aa7e6\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl -g \"http://localhost:3000/api/v1/events\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 70b7728875be2b3cdd177229caae24d054972e7e618f0cb133d748d5918b8933\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/doc/api/events/show_:_retrieve_information_about_requested_event.json
+++ b/doc/api/events/show_:_retrieve_information_about_requested_event.json
@@ -1,6 +1,6 @@
 {
   "resource": "Events",
-  "resource_explanation": "El Plano events API.\n\nEvent attributes :\n\n - `title` - Represents event name.\n - `description` - Represents event detailed description.\n - `status` - Represents event current status.\n   - `confirmed` - The event is confirmed. This is the default status.\n   - `tentative` - The event is tentatively confirmed.\n   - `cancelled` - The event is cancelled (deleted).\n\n - `recurrence` - Represents recurrence rules.\n - `timezone` - Timezone settings.\n - `start_at` - Represents when event starts.\n - `end_at` - Represents when event ends.\n - timestamps\n\n Also, includes reference to the event creator.\n",
+  "resource_explanation": "El Plano events API.\n\nEvent attributes :\n\n - `title` - Represents event name.\n - `description` - Represents event detailed description.\n - `status` - Represents event current status.\n   - `confirmed` - The event is confirmed. This is the default status.\n   - `tentative` - The event is tentatively confirmed.\n   - `cancelled` - The event is cancelled (deleted).\n\n - `recurrence` - Represents recurrence rules.\n - `timezone` - Timezone settings.\n - `start_at` - Represents when event starts.\n - `end_at` - Represents when event ends.\n - timestamps\n\n Also, includes reference to the event creator and attached course.\n",
   "http_method": "GET",
   "route": "api/v1/events/:id",
   "description": "SHOW : Retrieve information about requested event",
@@ -19,7 +19,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 2fed42c4553ea802e55204a461232496229f1ac4a0062cf519486da3d83cef79",
+        "Authorization": "Bearer 0e8d464e6323cfd1f9ea0447ccf6844ce78a259f6a4cfea3b92ee043615420c6",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -28,7 +28,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 200,
       "response_status_text": "OK",
-      "response_body": "{\n  \"data\": {\n    \"id\": \"2\",\n    \"type\": \"event\",\n    \"attributes\": {\n      \"title\": \"some_new_event\",\n      \"description\": null,\n      \"status\": \"confirmed\",\n      \"recurrence\": [\n        \"EXDATE;VALUE=DATE:20150610\",\n        \"RDATE;VALUE=DATE:20150609,20150611\",\n        \"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"\n      ],\n      \"start_at\": \"2019-02-28T00:00:00.000Z\",\n      \"end_at\": null,\n      \"timezone\": \"Etc/GMT+12\",\n      \"created_at\": \"2019-02-27T06:08:48.371Z\",\n      \"updated_at\": \"2019-02-27T06:08:48.371Z\"\n    },\n    \"relationships\": {\n      \"creator\": {\n        \"data\": {\n          \"id\": \"4\",\n          \"type\": \"student\"\n        }\n      }\n    }\n  }\n}",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"2\",\n    \"type\": \"event\",\n    \"attributes\": {\n      \"title\": \"some_new_event\",\n      \"description\": null,\n      \"status\": \"confirmed\",\n      \"recurrence\": [\n        \"EXDATE;VALUE=DATE:20150610\",\n        \"RDATE;VALUE=DATE:20150609,20150611\",\n        \"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"\n      ],\n      \"start_at\": \"2019-02-28T00:00:00.000Z\",\n      \"end_at\": null,\n      \"timezone\": \"Etc/GMT+12\",\n      \"created_at\": \"2019-02-27T06:43:20.800Z\",\n      \"updated_at\": \"2019-02-27T06:43:20.800Z\"\n    },\n    \"relationships\": {\n      \"creator\": {\n        \"data\": {\n          \"id\": \"9\",\n          \"type\": \"student\"\n        }\n      },\n      \"course\": {\n        \"data\": null\n      }\n    }\n  }\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -37,14 +37,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/json; charset=utf-8",
-        "ETag": "W/\"5165c8f154e0d866d1457e703bb7a0b7\"",
-        "X-Request-Id": "6fa3b417-5833-49a1-91a0-ca440a685071",
-        "X-Runtime": "0.006677",
+        "ETag": "W/\"646fe76a8f220831c0d5e9e8cbb75b36\"",
+        "X-Request-Id": "d0a2963e-4f98-438b-b3e9-aef07d30fc35",
+        "X-Runtime": "0.006533",
         "Vary": "Origin",
-        "Content-Length": "461"
+        "Content-Length": "484"
       },
       "response_content_type": "application/json; charset=utf-8",
-      "curl": "curl -g \"http://localhost:3000/api/v1/events/2\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 2fed42c4553ea802e55204a461232496229f1ac4a0062cf519486da3d83cef79\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl -g \"http://localhost:3000/api/v1/events/2\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 0e8d464e6323cfd1f9ea0447ccf6844ce78a259f6a4cfea3b92ee043615420c6\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/doc/api/events/update_:_updates_selected_event_information.json
+++ b/doc/api/events/update_:_updates_selected_event_information.json
@@ -1,6 +1,6 @@
 {
   "resource": "Events",
-  "resource_explanation": "El Plano events API.\n\nEvent attributes :\n\n - `title` - Represents event name.\n - `description` - Represents event detailed description.\n - `status` - Represents event current status.\n   - `confirmed` - The event is confirmed. This is the default status.\n   - `tentative` - The event is tentatively confirmed.\n   - `cancelled` - The event is cancelled (deleted).\n\n - `recurrence` - Represents recurrence rules.\n - `timezone` - Timezone settings.\n - `start_at` - Represents when event starts.\n - `end_at` - Represents when event ends.\n - timestamps\n\n Also, includes reference to the event creator.\n",
+  "resource_explanation": "El Plano events API.\n\nEvent attributes :\n\n - `title` - Represents event name.\n - `description` - Represents event detailed description.\n - `status` - Represents event current status.\n   - `confirmed` - The event is confirmed. This is the default status.\n   - `tentative` - The event is tentatively confirmed.\n   - `cancelled` - The event is cancelled (deleted).\n\n - `recurrence` - Represents recurrence rules.\n - `timezone` - Timezone settings.\n - `start_at` - Represents when event starts.\n - `end_at` - Represents when event ends.\n - timestamps\n\n Also, includes reference to the event creator and attached course.\n",
   "http_method": "PUT",
   "route": "api/v1/events/:id",
   "description": "UPDATE : Updates selected event information",
@@ -57,6 +57,14 @@
       "requred": true,
       "name": "timezone",
       "description": "Event timezone"
+    },
+    {
+      "scope": [
+        "data",
+        "attributes"
+      ],
+      "name": "course",
+      "description": "The course to which the event is attached. Included in \"relationships\" category"
     }
   ],
   "response_fields": [
@@ -66,11 +74,11 @@
     {
       "request_method": "PUT",
       "request_path": "api/v1/events/4",
-      "request_body": "{\"data\":{\"type\":\"event\",\"attributes\":{\"title\":\"Doloribus molestiae alias.\",\"description\":\"Quae qui iure. Officiis quidem mollitia. Dicta voluptatibus vel. Quibusdam et maiores. Reiciendis autem et.\",\"status\":\"cancelled\",\"start_at\":\"2019-02-26\",\"end_at\":\"2019-02-28\",\"timezone\":\"Etc/GMT+12\",\"recurrence\":[\"EXDATE;VALUE=DATE:20150610\",\"RDATE;VALUE=DATE:20150609,20150611\",\"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"]}}}",
+      "request_body": "{\"data\":{\"type\":\"event\",\"attributes\":{\"title\":\"Et voluptatem tempore.\",\"description\":\"Rerum placeat voluptatem. Error itaque eum. Magnam incidunt molestias. Blanditiis esse quos. Velit veritatis saepe.\",\"status\":\"cancelled\",\"start_at\":\"2019-02-26\",\"end_at\":\"2019-02-28\",\"timezone\":\"Etc/GMT+12\",\"recurrence\":[\"EXDATE;VALUE=DATE:20150610\",\"RDATE;VALUE=DATE:20150609,20150611\",\"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"]},\"relationships\":{\"course\":{\"data\":{\"id\":7,\"type\":\"course\"}}}}}",
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 55c4eed65f23e08ca009ff1df862dd9e7e35e28b5b4681ab2389b363aa9ecd54",
+        "Authorization": "Bearer f01a79860d01294b580c45e8ace1ebc9346c5c52d88d2ef336bd89186711303a",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -79,7 +87,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 200,
       "response_status_text": "OK",
-      "response_body": "{\n  \"data\": {\n    \"id\": \"4\",\n    \"type\": \"event\",\n    \"attributes\": {\n      \"title\": \"Doloribus molestiae alias.\",\n      \"description\": \"Quae qui iure. Officiis quidem mollitia. Dicta voluptatibus vel. Quibusdam et maiores. Reiciendis autem et.\",\n      \"status\": \"cancelled\",\n      \"recurrence\": [\n        \"EXDATE;VALUE=DATE:20150610\",\n        \"RDATE;VALUE=DATE:20150609,20150611\",\n        \"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"\n      ],\n      \"start_at\": \"2019-02-26T00:00:00.000Z\",\n      \"end_at\": \"2019-02-28T00:00:00.000Z\",\n      \"timezone\": \"Etc/GMT+12\",\n      \"created_at\": \"2019-02-27T06:08:48.447Z\",\n      \"updated_at\": \"2019-02-27T06:08:48.458Z\"\n    },\n    \"relationships\": {\n      \"creator\": {\n        \"data\": {\n          \"id\": \"8\",\n          \"type\": \"student\"\n        }\n      }\n    }\n  }\n}",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"4\",\n    \"type\": \"event\",\n    \"attributes\": {\n      \"title\": \"Et voluptatem tempore.\",\n      \"description\": \"Rerum placeat voluptatem. Error itaque eum. Magnam incidunt molestias. Blanditiis esse quos. Velit veritatis saepe.\",\n      \"status\": \"cancelled\",\n      \"recurrence\": [\n        \"EXDATE;VALUE=DATE:20150610\",\n        \"RDATE;VALUE=DATE:20150609,20150611\",\n        \"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"\n      ],\n      \"start_at\": \"2019-02-26T00:00:00.000Z\",\n      \"end_at\": \"2019-02-28T00:00:00.000Z\",\n      \"timezone\": \"Etc/GMT+12\",\n      \"created_at\": \"2019-02-27T06:43:20.881Z\",\n      \"updated_at\": \"2019-02-27T06:43:20.896Z\"\n    },\n    \"relationships\": {\n      \"creator\": {\n        \"data\": {\n          \"id\": \"13\",\n          \"type\": \"student\"\n        }\n      },\n      \"course\": {\n        \"data\": {\n          \"id\": \"7\",\n          \"type\": \"course\"\n        }\n      }\n    }\n  }\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -88,14 +96,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/json; charset=utf-8",
-        "ETag": "W/\"c8f2451b0a81f6efb4475c13a0b7cffa\"",
-        "X-Request-Id": "e5bb9d40-9b8b-4358-830c-b7ef5de17202",
-        "X-Runtime": "0.008644",
+        "ETag": "W/\"85eae896c83d79cb0411c52af2a610dd\"",
+        "X-Request-Id": "acb0e56b-b584-4ad1-9985-9d88f6a86f46",
+        "X-Runtime": "0.009280",
         "Vary": "Origin",
-        "Content-Length": "600"
+        "Content-Length": "650"
       },
       "response_content_type": "application/json; charset=utf-8",
-      "curl": "curl \"http://localhost:3000/api/v1/events/4\" -d '{\"data\":{\"type\":\"event\",\"attributes\":{\"title\":\"Doloribus molestiae alias.\",\"description\":\"Quae qui iure. Officiis quidem mollitia. Dicta voluptatibus vel. Quibusdam et maiores. Reiciendis autem et.\",\"status\":\"cancelled\",\"start_at\":\"2019-02-26\",\"end_at\":\"2019-02-28\",\"timezone\":\"Etc/GMT+12\",\"recurrence\":[\"EXDATE;VALUE=DATE:20150610\",\"RDATE;VALUE=DATE:20150609,20150611\",\"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"]}}}' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 55c4eed65f23e08ca009ff1df862dd9e7e35e28b5b4681ab2389b363aa9ecd54\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000/api/v1/events/4\" -d '{\"data\":{\"type\":\"event\",\"attributes\":{\"title\":\"Et voluptatem tempore.\",\"description\":\"Rerum placeat voluptatem. Error itaque eum. Magnam incidunt molestias. Blanditiis esse quos. Velit veritatis saepe.\",\"status\":\"cancelled\",\"start_at\":\"2019-02-26\",\"end_at\":\"2019-02-28\",\"timezone\":\"Etc/GMT+12\",\"recurrence\":[\"EXDATE;VALUE=DATE:20150610\",\"RDATE;VALUE=DATE:20150609,20150611\",\"RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3\"]},\"relationships\":{\"course\":{\"data\":{\"id\":7,\"type\":\"course\"}}}}}' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer f01a79860d01294b580c45e8ace1ebc9346c5c52d88d2ef336bd89186711303a\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/doc/api/group's_invites/create_:_create_new_invite.json
+++ b/doc/api/group's_invites/create_:_create_new_invite.json
@@ -23,11 +23,11 @@
     {
       "request_method": "POST",
       "request_path": "api/v1/group/invites",
-      "request_body": "{\"data\":{\"type\":\"invite\",\"attributes\":{\"email\":\"odea@carterherzog.name\"}}}",
+      "request_body": "{\"data\":{\"type\":\"invite\",\"attributes\":{\"email\":\"nohemihayes@cole.net\"}}}",
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 1a0c219333c40c87a069812ec0c10cb772897348d1fd9ecc7bbcb43373af0ce0",
+        "Authorization": "Bearer d51dba305f00fda5de4fbe5022a773c8765a3872a1bb4f699ae56f912d8bd6ec",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -36,7 +36,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 201,
       "response_status_text": "Created",
-      "response_body": "{\n  \"data\": {\n    \"id\": \"3\",\n    \"type\": \"invite\",\n    \"attributes\": {\n      \"email\": \"odea@carterherzog.name\",\n      \"invitation_token\": \"6BBWpfsKyJFdTUs_NDLp\",\n      \"sent_at\": \"2019-02-27T06:08:48.607Z\",\n      \"accepted_at\": null,\n      \"created_at\": \"2019-02-27T06:08:48.607Z\",\n      \"updated_at\": \"2019-02-27T06:08:48.607Z\",\n      \"status\": \"pending\"\n    },\n    \"relationships\": {\n      \"sender\": {\n        \"data\": {\n          \"id\": \"15\",\n          \"type\": \"student\"\n        }\n      },\n      \"recipient\": {\n        \"data\": null\n      },\n      \"group\": {\n        \"data\": {\n          \"id\": \"8\",\n          \"type\": \"group\"\n        }\n      }\n    }\n  }\n}",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"3\",\n    \"type\": \"invite\",\n    \"attributes\": {\n      \"email\": \"nohemihayes@cole.net\",\n      \"invitation_token\": \"9dknrqxnREQDPmyiLxBy\",\n      \"sent_at\": \"2019-02-27T06:43:21.079Z\",\n      \"accepted_at\": null,\n      \"created_at\": \"2019-02-27T06:43:21.079Z\",\n      \"updated_at\": \"2019-02-27T06:43:21.079Z\",\n      \"status\": \"pending\"\n    },\n    \"relationships\": {\n      \"sender\": {\n        \"data\": {\n          \"id\": \"20\",\n          \"type\": \"student\"\n        }\n      },\n      \"recipient\": {\n        \"data\": null\n      },\n      \"group\": {\n        \"data\": {\n          \"id\": \"13\",\n          \"type\": \"group\"\n        }\n      }\n    }\n  }\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -45,14 +45,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/json; charset=utf-8",
-        "ETag": "W/\"2a885d005c8aa2c0f06f60398c686193\"",
-        "X-Request-Id": "20ee3655-80d7-485e-9629-09f5e8450d6b",
-        "X-Runtime": "0.047655",
+        "ETag": "W/\"45ddba50b3751671a57cfea7e4fa6392\"",
+        "X-Request-Id": "12788b28-c4e7-4e62-bc08-f914fe4a2948",
+        "X-Runtime": "0.053218",
         "Vary": "Origin",
-        "Content-Length": "414"
+        "Content-Length": "413"
       },
       "response_content_type": "application/json; charset=utf-8",
-      "curl": "curl \"http://localhost:3000/api/v1/group/invites\" -d '{\"data\":{\"type\":\"invite\",\"attributes\":{\"email\":\"odea@carterherzog.name\"}}}' -X POST \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 1a0c219333c40c87a069812ec0c10cb772897348d1fd9ecc7bbcb43373af0ce0\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000/api/v1/group/invites\" -d '{\"data\":{\"type\":\"invite\",\"attributes\":{\"email\":\"nohemihayes@cole.net\"}}}' -X POST \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer d51dba305f00fda5de4fbe5022a773c8765a3872a1bb4f699ae56f912d8bd6ec\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/doc/api/group's_invites/index_:_retrieve_user's_group_invitations.json
+++ b/doc/api/group's_invites/index_:_retrieve_user's_group_invitations.json
@@ -19,7 +19,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 21e684b56ad3b9520dbe756f473934a3822bad21da0472a02e5a0aaf7caa36d6",
+        "Authorization": "Bearer cbd26345b8562f198177bd0608f5ae18533182672e772cac983b5651049a226c",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -28,7 +28,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 200,
       "response_status_text": "OK",
-      "response_body": "{\n  \"data\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"invite\",\n      \"attributes\": {\n        \"email\": \"letisha@lindgren.co\",\n        \"invitation_token\": \"-Vszz2yQFXQDb8hpD-xv\",\n        \"sent_at\": \"2019-02-27T06:08:48.528Z\",\n        \"accepted_at\": null,\n        \"created_at\": \"2019-02-27T06:08:48.527Z\",\n        \"updated_at\": \"2019-02-27T06:08:48.527Z\",\n        \"status\": \"pending\"\n      },\n      \"relationships\": {\n        \"sender\": {\n          \"data\": {\n            \"id\": \"12\",\n            \"type\": \"student\"\n          }\n        },\n        \"recipient\": {\n          \"data\": null\n        },\n        \"group\": {\n          \"data\": {\n            \"id\": \"6\",\n            \"type\": \"group\"\n          }\n        }\n      }\n    }\n  ]\n}",
+      "response_body": "{\n  \"data\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"invite\",\n      \"attributes\": {\n        \"email\": \"buck@hudson.co\",\n        \"invitation_token\": \"CAa4ca5keoER2xvTNoEg\",\n        \"sent_at\": \"2019-02-27T06:43:20.980Z\",\n        \"accepted_at\": null,\n        \"created_at\": \"2019-02-27T06:43:20.980Z\",\n        \"updated_at\": \"2019-02-27T06:43:20.980Z\",\n        \"status\": \"pending\"\n      },\n      \"relationships\": {\n        \"sender\": {\n          \"data\": {\n            \"id\": \"17\",\n            \"type\": \"student\"\n          }\n        },\n        \"recipient\": {\n          \"data\": null\n        },\n        \"group\": {\n          \"data\": {\n            \"id\": \"11\",\n            \"type\": \"group\"\n          }\n        }\n      }\n    }\n  ]\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -37,14 +37,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/json; charset=utf-8",
-        "ETag": "W/\"0cbd5195a62a6b8fe119ecfc234c0cde\"",
-        "X-Request-Id": "43bc76f6-e36b-41ac-a0da-aff85e174eec",
-        "X-Runtime": "0.011231",
+        "ETag": "W/\"afd381da5ceb406af05bd9ca7bb12430\"",
+        "X-Request-Id": "07d74f03-6d8e-48a0-ab1a-47d2622703db",
+        "X-Runtime": "0.010892",
         "Vary": "Origin",
-        "Content-Length": "413"
+        "Content-Length": "409"
       },
       "response_content_type": "application/json; charset=utf-8",
-      "curl": "curl -g \"http://localhost:3000/api/v1/group/invites\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 21e684b56ad3b9520dbe756f473934a3822bad21da0472a02e5a0aaf7caa36d6\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl -g \"http://localhost:3000/api/v1/group/invites\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer cbd26345b8562f198177bd0608f5ae18533182672e772cac983b5651049a226c\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/doc/api/group's_invites/show_:_retrieve_information_about_requested_invite.json
+++ b/doc/api/group's_invites/show_:_retrieve_information_about_requested_invite.json
@@ -19,7 +19,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 470c7a37d5108ddb10307489c06cb7f255bdcdd014decca121d40250574d8e6e",
+        "Authorization": "Bearer 9391b4f7acdaddfbf39c9c57bf7645a0055e5f7ffa14af6b7d4567ce5a857e27",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -28,7 +28,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 200,
       "response_status_text": "OK",
-      "response_body": "{\n  \"data\": {\n    \"id\": \"2\",\n    \"type\": \"invite\",\n    \"attributes\": {\n      \"email\": \"babarazemlak@swift.net\",\n      \"invitation_token\": \"vPZPjm7CpiJ3TcT2DAMf\",\n      \"sent_at\": \"2019-02-27T06:08:48.571Z\",\n      \"accepted_at\": null,\n      \"created_at\": \"2019-02-27T06:08:48.571Z\",\n      \"updated_at\": \"2019-02-27T06:08:48.571Z\",\n      \"status\": \"pending\"\n    },\n    \"relationships\": {\n      \"sender\": {\n        \"data\": {\n          \"id\": \"14\",\n          \"type\": \"student\"\n        }\n      },\n      \"recipient\": {\n        \"data\": null\n      },\n      \"group\": {\n        \"data\": {\n          \"id\": \"7\",\n          \"type\": \"group\"\n        }\n      }\n    }\n  }\n}",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"2\",\n    \"type\": \"invite\",\n    \"attributes\": {\n      \"email\": \"carsonhalvorson@rohan.org\",\n      \"invitation_token\": \"AP4sv6JFakk1dUGpjKxg\",\n      \"sent_at\": \"2019-02-27T06:43:21.034Z\",\n      \"accepted_at\": null,\n      \"created_at\": \"2019-02-27T06:43:21.034Z\",\n      \"updated_at\": \"2019-02-27T06:43:21.034Z\",\n      \"status\": \"pending\"\n    },\n    \"relationships\": {\n      \"sender\": {\n        \"data\": {\n          \"id\": \"19\",\n          \"type\": \"student\"\n        }\n      },\n      \"recipient\": {\n        \"data\": null\n      },\n      \"group\": {\n        \"data\": {\n          \"id\": \"12\",\n          \"type\": \"group\"\n        }\n      }\n    }\n  }\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -37,14 +37,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/json; charset=utf-8",
-        "ETag": "W/\"19a4d3b913b7cf9d2d1bee7c5ad09f0d\"",
-        "X-Request-Id": "1d5fd861-fd72-4ca4-b2b5-18e6783b6987",
-        "X-Runtime": "0.006951",
+        "ETag": "W/\"534a4020486a2afc6363f3eebef08763\"",
+        "X-Request-Id": "26e60c3a-6f53-46d1-9146-85412d209e50",
+        "X-Runtime": "0.008068",
         "Vary": "Origin",
-        "Content-Length": "414"
+        "Content-Length": "418"
       },
       "response_content_type": "application/json; charset=utf-8",
-      "curl": "curl -g \"http://localhost:3000/api/v1/group/invites/2\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 470c7a37d5108ddb10307489c06cb7f255bdcdd014decca121d40250574d8e6e\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl -g \"http://localhost:3000/api/v1/group/invites/2\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 9391b4f7acdaddfbf39c9c57bf7645a0055e5f7ffa14af6b7d4567ce5a857e27\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/doc/api/group_members/index_:_retrieve_group_members.json
+++ b/doc/api/group_members/index_:_retrieve_group_members.json
@@ -19,7 +19,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 40cecef50172c2c4e8f3d0d904715092fc6830cb8c5e7ecc55e6e23e0fa3e9cc",
+        "Authorization": "Bearer f40f7d17f1de76f3851f5c132ab5cafb761014729f3fb39dc5c9803b2c615ec0",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -28,7 +28,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 200,
       "response_status_text": "OK",
-      "response_body": "{\n  \"data\": [\n    {\n      \"id\": \"17\",\n      \"type\": \"student\",\n      \"attributes\": {\n        \"full_name\": \"Jamison Lai Bins II\",\n        \"email\": \"magdalenschimmel@yost.io\",\n        \"phone\": \"(594) 530-3913\",\n        \"about\": \"Temporibus quia dolor. Praesentium adipisci nulla. Mollitia non perferendis. Sint libero nisi. Dicta provident alias.\",\n        \"social_networks\": {\n          \"twitter\": \"http://twitter/magdalen_reichel\",\n          \"facebook\": \"http://facebook/cedrick\"\n        },\n        \"president\": false,\n        \"created_at\": \"2019-02-27T06:08:48.665Z\",\n        \"updated_at\": \"2019-02-27T06:08:48.665Z\"\n      },\n      \"relationships\": {\n        \"user\": {\n          \"data\": {\n            \"id\": \"16\",\n            \"type\": \"user\"\n          }\n        }\n      }\n    }\n  ]\n}",
+      "response_body": "{\n  \"data\": [\n    {\n      \"id\": \"22\",\n      \"type\": \"student\",\n      \"attributes\": {\n        \"full_name\": \"Trista Cheyenne Lubowitz\",\n        \"email\": \"bereniceledner@wunsch.info\",\n        \"phone\": \"(424) 550-0451\",\n        \"about\": \"Enim unde eveniet. Necessitatibus unde molestiae. Pariatur dolor repellat. Cupiditate rerum quam. Esse in voluptatum.\",\n        \"social_networks\": {\n          \"twitter\": \"http://twitter/brittanie.altenwerth\",\n          \"facebook\": \"http://facebook/dannette\"\n        },\n        \"president\": false,\n        \"created_at\": \"2019-02-27T06:43:21.147Z\",\n        \"updated_at\": \"2019-02-27T06:43:21.147Z\"\n      },\n      \"relationships\": {\n        \"user\": {\n          \"data\": {\n            \"id\": \"21\",\n            \"type\": \"user\"\n          }\n        }\n      }\n    }\n  ]\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -37,14 +37,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/json; charset=utf-8",
-        "ETag": "W/\"4696d0f8d612c984121234c6c0fb3979\"",
-        "X-Request-Id": "6a21b7f1-a01e-438b-a538-ed80fd0eb79a",
-        "X-Runtime": "0.007191",
+        "ETag": "W/\"ff3e105bad4cc7feea8f11fa9f3ea457\"",
+        "X-Request-Id": "6df11a2d-bd5f-419e-a902-9035be1d9de4",
+        "X-Runtime": "0.009852",
         "Vary": "Origin",
-        "Content-Length": "535"
+        "Content-Length": "547"
       },
       "response_content_type": "application/json; charset=utf-8",
-      "curl": "curl -g \"http://localhost:3000/api/v1/group/students\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 40cecef50172c2c4e8f3d0d904715092fc6830cb8c5e7ecc55e6e23e0fa3e9cc\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl -g \"http://localhost:3000/api/v1/group/students\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer f40f7d17f1de76f3851f5c132ab5cafb761014729f3fb39dc5c9803b2c615ec0\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/doc/api/group_members/show_:_show_information_about_particular_group_member.json
+++ b/doc/api/group_members/show_:_show_information_about_particular_group_member.json
@@ -14,12 +14,12 @@
   "requests": [
     {
       "request_method": "GET",
-      "request_path": "api/v1/group/students/19",
+      "request_path": "api/v1/group/students/24",
       "request_body": null,
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer c5c72d98866c9e9afbd13d9f20555dbabadf18dd70db2b2973d3040ce4787813",
+        "Authorization": "Bearer 5f044399d098c716369ecdb300c99a64a9b9003e0460c665e0bcf1f2f7e34532",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -28,7 +28,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 200,
       "response_status_text": "OK",
-      "response_body": "{\n  \"data\": {\n    \"id\": \"19\",\n    \"type\": \"student\",\n    \"attributes\": {\n      \"full_name\": \"Harland Winter Borer I\",\n      \"email\": \"roseanna@marquardt.io\",\n      \"phone\": \"231.594.5616\",\n      \"about\": \"Aperiam ratione inventore. Non minima numquam. Cumque sed unde. Quod ea aut. Minus et quae.\",\n      \"social_networks\": {\n        \"twitter\": \"http://twitter/carmela\",\n        \"facebook\": \"http://facebook/vernie.wiza\"\n      },\n      \"president\": false,\n      \"created_at\": \"2019-02-27T06:08:48.693Z\",\n      \"updated_at\": \"2019-02-27T06:08:48.693Z\"\n    },\n    \"relationships\": {\n      \"group\": {\n        \"data\": {\n          \"id\": \"10\",\n          \"type\": \"group\"\n        }\n      },\n      \"user\": {\n        \"data\": {\n          \"id\": \"18\",\n          \"type\": \"user\"\n        }\n      }\n    }\n  },\n  \"included\": [\n    {\n      \"id\": \"18\",\n      \"type\": \"user\",\n      \"attributes\": {\n        \"email\": \"krystinarunte@quitzon.net\",\n        \"username\": \"milford_morar\",\n        \"admin\": false,\n        \"created_at\": \"2019-02-27T06:08:48.683Z\",\n        \"updated_at\": \"2019-02-27T06:08:48.683Z\",\n        \"avatar_url\": \"https://www.gravatar.com/avatar/fab573ea56541aa2d203d5ca42466ec1?s=200&d=identicon\",\n        \"confirmed\": true\n      },\n      \"relationships\": {\n        \"student\": {\n          \"data\": {\n            \"id\": \"19\",\n            \"type\": \"student\"\n          }\n        }\n      }\n    }\n  ]\n}",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"24\",\n    \"type\": \"student\",\n    \"attributes\": {\n      \"full_name\": \"Jenae Leona McKenzie\",\n      \"email\": \"nicholas@langworthwalsh.name\",\n      \"phone\": \"683.263.9788\",\n      \"about\": \"Voluptatem in ex. Accusantium sed fuga. In hic alias. Qui aut est. A consequatur nam.\",\n      \"social_networks\": {\n        \"twitter\": \"http://twitter/ozzie.johnston\",\n        \"facebook\": \"http://facebook/refugia\"\n      },\n      \"president\": false,\n      \"created_at\": \"2019-02-27T06:43:21.186Z\",\n      \"updated_at\": \"2019-02-27T06:43:21.186Z\"\n    },\n    \"relationships\": {\n      \"group\": {\n        \"data\": {\n          \"id\": \"15\",\n          \"type\": \"group\"\n        }\n      },\n      \"user\": {\n        \"data\": {\n          \"id\": \"23\",\n          \"type\": \"user\"\n        }\n      }\n    }\n  },\n  \"included\": [\n    {\n      \"id\": \"23\",\n      \"type\": \"user\",\n      \"attributes\": {\n        \"email\": \"gilberto@kihn.name\",\n        \"username\": \"elsie\",\n        \"admin\": false,\n        \"created_at\": \"2019-02-27T06:43:21.171Z\",\n        \"updated_at\": \"2019-02-27T06:43:21.171Z\",\n        \"avatar_url\": \"https://www.gravatar.com/avatar/07e461fe00f34e92ed2d7b1597050fbd?s=200&d=identicon\",\n        \"confirmed\": true\n      },\n      \"relationships\": {\n        \"student\": {\n          \"data\": {\n            \"id\": \"24\",\n            \"type\": \"student\"\n          }\n        }\n      }\n    }\n  ]\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -37,14 +37,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/json; charset=utf-8",
-        "ETag": "W/\"e5815702087f762af41296580343b9ef\"",
-        "X-Request-Id": "801105ae-8461-4b3a-9127-f2339583872b",
-        "X-Runtime": "0.007782",
+        "ETag": "W/\"b196e82a93a762cad270e2db70f036d1\"",
+        "X-Request-Id": "be1c465a-5bbe-4c05-a1da-c209b83a25f2",
+        "X-Runtime": "0.009414",
         "Vary": "Origin",
-        "Content-Length": "941"
+        "Content-Length": "928"
       },
       "response_content_type": "application/json; charset=utf-8",
-      "curl": "curl -g \"http://localhost:3000/api/v1/group/students/19\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer c5c72d98866c9e9afbd13d9f20555dbabadf18dd70db2b2973d3040ce4787813\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl -g \"http://localhost:3000/api/v1/group/students/24\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 5f044399d098c716369ecdb300c99a64a9b9003e0460c665e0bcf1f2f7e34532\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/doc/api/groups/create_:_creates_new_group.json
+++ b/doc/api/groups/create_:_creates_new_group.json
@@ -32,11 +32,11 @@
     {
       "request_method": "POST",
       "request_path": "api/v1/group",
-      "request_body": "{\"data\":{\"type\":\"group\",\"attributes\":{\"title\":\"Quod ex mollitia.\",\"number\":\"62587\"}}}",
+      "request_body": "{\"data\":{\"type\":\"group\",\"attributes\":{\"title\":\"Provident nihil in.\",\"number\":\"52625\"}}}",
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer c698ddadb058a71bdbf73ce4e2e7b71ba6e8545d81a8ebf5c0762f77c461054e",
+        "Authorization": "Bearer e0c0d91753a4724c457ec8bdc558d9014503468366b9a2d07d59a22e48fa1e6f",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -45,7 +45,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 201,
       "response_status_text": "Created",
-      "response_body": "{\n  \"data\": {\n    \"id\": \"12\",\n    \"type\": \"group\",\n    \"attributes\": {\n      \"number\": \"62587\",\n      \"title\": \"Quod ex mollitia.\",\n      \"created_at\": \"2019-02-27T06:08:48.749Z\",\n      \"updated_at\": \"2019-02-27T06:08:48.749Z\"\n    },\n    \"relationships\": {\n      \"students\": {\n        \"data\": [\n          {\n            \"id\": \"21\",\n            \"type\": \"student\"\n          }\n        ]\n      }\n    }\n  }\n}",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"17\",\n    \"type\": \"group\",\n    \"attributes\": {\n      \"number\": \"52625\",\n      \"title\": \"Provident nihil in.\",\n      \"created_at\": \"2019-02-27T06:43:21.260Z\",\n      \"updated_at\": \"2019-02-27T06:43:21.260Z\"\n    },\n    \"relationships\": {\n      \"students\": {\n        \"data\": [\n          {\n            \"id\": \"26\",\n            \"type\": \"student\"\n          }\n        ]\n      }\n    }\n  }\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -54,14 +54,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/json; charset=utf-8",
-        "ETag": "W/\"e8161adfff23a3c1b94b080da83e6db9\"",
-        "X-Request-Id": "e4e5a111-7dea-45da-b5a4-78adb179bf9a",
-        "X-Runtime": "0.009740",
+        "ETag": "W/\"ec187cc9666b3796ce3a9745faa8a8ba\"",
+        "X-Request-Id": "95e655ed-5063-4aac-977f-6e774561bd4c",
+        "X-Runtime": "0.015417",
         "Vary": "Origin",
-        "Content-Length": "244"
+        "Content-Length": "246"
       },
       "response_content_type": "application/json; charset=utf-8",
-      "curl": "curl \"http://localhost:3000/api/v1/group\" -d '{\"data\":{\"type\":\"group\",\"attributes\":{\"title\":\"Quod ex mollitia.\",\"number\":\"62587\"}}}' -X POST \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer c698ddadb058a71bdbf73ce4e2e7b71ba6e8545d81a8ebf5c0762f77c461054e\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000/api/v1/group\" -d '{\"data\":{\"type\":\"group\",\"attributes\":{\"title\":\"Provident nihil in.\",\"number\":\"52625\"}}}' -X POST \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer e0c0d91753a4724c457ec8bdc558d9014503468366b9a2d07d59a22e48fa1e6f\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/doc/api/groups/delete_:_deletes_user's_group.json
+++ b/doc/api/groups/delete_:_deletes_user's_group.json
@@ -19,7 +19,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer e738d07897ddf83b4078cb9882be35e431cda4399e52df9abd284b164a7d0c72",
+        "Authorization": "Bearer f6e5d95d82c3edfeeb46ceebcb600dd19820a906ec05434513cf777b49fa9cef",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -36,12 +36,12 @@
         "X-Content-Type-Options": "nosniff",
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
-        "X-Request-Id": "e3876d20-31f5-45ce-acfe-e489d9a4b503",
-        "X-Runtime": "0.007246",
+        "X-Request-Id": "2fc5ca3a-6f8c-45f9-891c-595d1805ecce",
+        "X-Runtime": "0.012595",
         "Vary": "Origin"
       },
       "response_content_type": null,
-      "curl": "curl \"http://localhost:3000/api/v1/group\" -d '' -X DELETE \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer e738d07897ddf83b4078cb9882be35e431cda4399e52df9abd284b164a7d0c72\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000/api/v1/group\" -d '' -X DELETE \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer f6e5d95d82c3edfeeb46ceebcb600dd19820a906ec05434513cf777b49fa9cef\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/doc/api/groups/show_:_retrieve_information_about_user's_group.json
+++ b/doc/api/groups/show_:_retrieve_information_about_user's_group.json
@@ -19,7 +19,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer aa78525bf2d0f2a081b6c8c5fa4b2cf3e020dd9044ca77cb2fdf8554c327c46a",
+        "Authorization": "Bearer 6e83e5e822bdac2bf6e89dc0b6dfe8394749b49a5302600f076144b2ebbd8bb0",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -28,7 +28,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 200,
       "response_status_text": "OK",
-      "response_body": "{\n  \"data\": {\n    \"id\": \"11\",\n    \"type\": \"group\",\n    \"attributes\": {\n      \"number\": \"2307768295\",\n      \"title\": \"Esse temporibus placeat.\",\n      \"created_at\": \"2019-02-27T06:08:48.717Z\",\n      \"updated_at\": \"2019-02-27T06:08:48.717Z\"\n    },\n    \"relationships\": {\n      \"students\": {\n        \"data\": [\n          {\n            \"id\": \"20\",\n            \"type\": \"student\"\n          }\n        ]\n      }\n    }\n  }\n}",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"16\",\n    \"type\": \"group\",\n    \"attributes\": {\n      \"number\": \"6614866314\",\n      \"title\": \"Ut sit tempore.\",\n      \"created_at\": \"2019-02-27T06:43:21.215Z\",\n      \"updated_at\": \"2019-02-27T06:43:21.215Z\"\n    },\n    \"relationships\": {\n      \"students\": {\n        \"data\": [\n          {\n            \"id\": \"25\",\n            \"type\": \"student\"\n          }\n        ]\n      }\n    }\n  }\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -37,14 +37,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/json; charset=utf-8",
-        "ETag": "W/\"359a272873382df2a56f77715fad4256\"",
-        "X-Request-Id": "2fde89e2-2848-4e1b-99e8-635f7676ae57",
-        "X-Runtime": "0.007760",
+        "ETag": "W/\"a26ad1992944f6b8a780158190cea64a\"",
+        "X-Request-Id": "6ac0321a-2a17-42b9-995c-ba2a742b291e",
+        "X-Runtime": "0.008884",
         "Vary": "Origin",
-        "Content-Length": "256"
+        "Content-Length": "247"
       },
       "response_content_type": "application/json; charset=utf-8",
-      "curl": "curl -g \"http://localhost:3000/api/v1/group\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer aa78525bf2d0f2a081b6c8c5fa4b2cf3e020dd9044ca77cb2fdf8554c327c46a\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl -g \"http://localhost:3000/api/v1/group\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 6e83e5e822bdac2bf6e89dc0b6dfe8394749b49a5302600f076144b2ebbd8bb0\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/doc/api/groups/update_:_updates_group_information.json
+++ b/doc/api/groups/update_:_updates_group_information.json
@@ -32,11 +32,11 @@
     {
       "request_method": "PUT",
       "request_path": "api/v1/group",
-      "request_body": "{\"data\":{\"type\":\"group\",\"attributes\":{\"title\":\"Nobis consequatur illum.\",\"number\":\"77611\"}}}",
+      "request_body": "{\"data\":{\"type\":\"group\",\"attributes\":{\"title\":\"Non laudantium voluptatem.\",\"number\":\"27121\"}}}",
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 40ffd413c8cbc529e835d8f470cdf620947b80e35f5637e0eb2d5385752efb54",
+        "Authorization": "Bearer 9411180e7975d4bbe19c887052211aed5de4e10c67d0e29546d95c3331e6be01",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -45,7 +45,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 200,
       "response_status_text": "OK",
-      "response_body": "{\n  \"data\": {\n    \"id\": \"13\",\n    \"type\": \"group\",\n    \"attributes\": {\n      \"number\": \"77611\",\n      \"title\": \"Nobis consequatur illum.\",\n      \"created_at\": \"2019-02-27T06:08:48.767Z\",\n      \"updated_at\": \"2019-02-27T06:08:48.777Z\"\n    },\n    \"relationships\": {\n      \"students\": {\n        \"data\": [\n          {\n            \"id\": \"22\",\n            \"type\": \"student\"\n          }\n        ]\n      }\n    }\n  }\n}",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"18\",\n    \"type\": \"group\",\n    \"attributes\": {\n      \"number\": \"27121\",\n      \"title\": \"Non laudantium voluptatem.\",\n      \"created_at\": \"2019-02-27T06:43:21.285Z\",\n      \"updated_at\": \"2019-02-27T06:43:21.297Z\"\n    },\n    \"relationships\": {\n      \"students\": {\n        \"data\": [\n          {\n            \"id\": \"27\",\n            \"type\": \"student\"\n          }\n        ]\n      }\n    }\n  }\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -54,14 +54,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/json; charset=utf-8",
-        "ETag": "W/\"4dd6be57d82fb6f0a34639cad35bfdbd\"",
-        "X-Request-Id": "9ed8ece0-7920-47ec-b848-07e6f810b9b5",
-        "X-Runtime": "0.007657",
+        "ETag": "W/\"0e881744b67978b481a340014c34b59d\"",
+        "X-Request-Id": "3eecd040-57dc-432c-871f-bd9985655a08",
+        "X-Runtime": "0.009480",
         "Vary": "Origin",
-        "Content-Length": "251"
+        "Content-Length": "253"
       },
       "response_content_type": "application/json; charset=utf-8",
-      "curl": "curl \"http://localhost:3000/api/v1/group\" -d '{\"data\":{\"type\":\"group\",\"attributes\":{\"title\":\"Nobis consequatur illum.\",\"number\":\"77611\"}}}' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 40ffd413c8cbc529e835d8f470cdf620947b80e35f5637e0eb2d5385752efb54\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000/api/v1/group\" -d '{\"data\":{\"type\":\"group\",\"attributes\":{\"title\":\"Non laudantium voluptatem.\",\"number\":\"27121\"}}}' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 9411180e7975d4bbe19c887052211aed5de4e10c67d0e29546d95c3331e6be01\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/doc/api/index.json
+++ b/doc/api/index.json
@@ -1,8 +1,49 @@
 {
   "resources": [
     {
+      "name": "Courses",
+      "explanation": "El Plano courses API.\n\nCourse attributes :\n\n - `title` - Represents course name(human readable identity).\n - timestamps\n\n Also, includes reference to the course lecturer.\n",
+      "examples": [
+        {
+          "description": "CREATE : Create new course",
+          "link": "courses/create_:_create_new_course.json",
+          "groups": "all",
+          "route": "api/v1/courses",
+          "method": "post"
+        },
+        {
+          "description": "DELETE : Delete selected course",
+          "link": "courses/delete_:_delete_selected_course.json",
+          "groups": "all",
+          "route": "api/v1/courses/:id",
+          "method": "delete"
+        },
+        {
+          "description": "INDEX : Retrieve courses created by authenticated user",
+          "link": "courses/index_:_retrieve_courses_created_by_authenticated_user.json",
+          "groups": "all",
+          "route": "api/v1/courses",
+          "method": "get"
+        },
+        {
+          "description": "SHOW : Retrieve information about requested course",
+          "link": "courses/show_:_retrieve_information_about_requested_course.json",
+          "groups": "all",
+          "route": "api/v1/courses/:id",
+          "method": "get"
+        },
+        {
+          "description": "UPDATE : Update selected course information",
+          "link": "courses/update_:_update_selected_course_information.json",
+          "groups": "all",
+          "route": "api/v1/courses/:id",
+          "method": "put"
+        }
+      ]
+    },
+    {
       "name": "Events",
-      "explanation": "El Plano events API.\n\nEvent attributes :\n\n - `title` - Represents event name.\n - `description` - Represents event detailed description.\n - `status` - Represents event current status.\n   - `confirmed` - The event is confirmed. This is the default status.\n   - `tentative` - The event is tentatively confirmed.\n   - `cancelled` - The event is cancelled (deleted).\n\n - `recurrence` - Represents recurrence rules.\n - `timezone` - Timezone settings.\n - `start_at` - Represents when event starts.\n - `end_at` - Represents when event ends.\n - timestamps\n\n Also, includes reference to the event creator.\n",
+      "explanation": "El Plano events API.\n\nEvent attributes :\n\n - `title` - Represents event name.\n - `description` - Represents event detailed description.\n - `status` - Represents event current status.\n   - `confirmed` - The event is confirmed. This is the default status.\n   - `tentative` - The event is tentatively confirmed.\n   - `cancelled` - The event is cancelled (deleted).\n\n - `recurrence` - Represents recurrence rules.\n - `timezone` - Timezone settings.\n - `start_at` - Represents when event starts.\n - `end_at` - Represents when event ends.\n - timestamps\n\n Also, includes reference to the event creator and attached course.\n",
       "examples": [
         {
           "description": "CREATE : Creates new event",
@@ -118,6 +159,47 @@
           "link": "groups/update_:_updates_group_information.json",
           "groups": "all",
           "route": "api/v1/group",
+          "method": "put"
+        }
+      ]
+    },
+    {
+      "name": "Lecturers",
+      "explanation": "El Plano lecturers API.\n\nCourse attributes :\n\n - `first_name`\n - `last_name`\n - `patronymic`\n - timestamps\n\n Also, includes reference to the courses.\n",
+      "examples": [
+        {
+          "description": "CREATE : Create new lecturer",
+          "link": "lecturers/create_:_create_new_lecturer.json",
+          "groups": "all",
+          "route": "api/v1/lecturers",
+          "method": "post"
+        },
+        {
+          "description": "DELETE : Delete selected lecturer",
+          "link": "lecturers/delete_:_delete_selected_lecturer.json",
+          "groups": "all",
+          "route": "api/v1/lecturers/:id",
+          "method": "delete"
+        },
+        {
+          "description": "INDEX : Retrieve lecturers created by authenticated user",
+          "link": "lecturers/index_:_retrieve_lecturers_created_by_authenticated_user.json",
+          "groups": "all",
+          "route": "api/v1/lecturers",
+          "method": "get"
+        },
+        {
+          "description": "SHOW : Retrieve information about requested lecturer",
+          "link": "lecturers/show_:_retrieve_information_about_requested_lecturer.json",
+          "groups": "all",
+          "route": "api/v1/lecturers/:id",
+          "method": "get"
+        },
+        {
+          "description": "UPDATE : Update selected lecturer information",
+          "link": "lecturers/update_:_update_selected_lecturer_information.json",
+          "groups": "all",
+          "route": "api/v1/lecturers/:id",
           "method": "put"
         }
       ]

--- a/doc/api/lecturers/create_:_create_new_lecturer.json
+++ b/doc/api/lecturers/create_:_create_new_lecturer.json
@@ -1,0 +1,84 @@
+{
+  "resource": "Lecturers",
+  "resource_explanation": "El Plano lecturers API.\n\nCourse attributes :\n\n - `first_name`\n - `last_name`\n - `patronymic`\n - timestamps\n\n Also, includes reference to the courses.\n",
+  "http_method": "POST",
+  "route": "api/v1/lecturers",
+  "description": "CREATE : Create new lecturer",
+  "explanation": "Create and return created lecturer.\n",
+  "parameters": [
+    {
+      "scope": [
+        "dta",
+        "attributes"
+      ],
+      "requred": true,
+      "name": "first_name",
+      "description": "Lecturer first name"
+    },
+    {
+      "scope": [
+        "dta",
+        "attributes"
+      ],
+      "requred": true,
+      "name": "last_name",
+      "description": "Lecturer last name"
+    },
+    {
+      "scope": [
+        "dta",
+        "attributes"
+      ],
+      "requred": true,
+      "name": "patronymic",
+      "description": "Lecturer patronymic"
+    },
+    {
+      "scope": [
+        "dta",
+        "attributes"
+      ],
+      "name": "courses",
+      "description": "Courses of the lecturer. Included in \"relationships\" category"
+    }
+  ],
+  "response_fields": [
+
+  ],
+  "requests": [
+    {
+      "request_method": "POST",
+      "request_path": "api/v1/lecturers",
+      "request_body": "{\"data\":{\"type\":\"lecturer\",\"attributes\":{\"first_name\":\"Debera\",\"last_name\":\"Bednar\",\"patronymic\":\"Ms.\"},\"relationships\":{\"courses\":{\"data\":[{\"id\":10,\"type\":\"courses\"}]}}}}",
+      "request_headers": {
+        "Accept": "application/vnd.api+json",
+        "Content-Type": "application/vnd.api+json",
+        "Authorization": "Bearer e45dc1d6d25d621808e0dd4cdbd493064d2e997de09d4d1e8b8ef38c43ad6a39",
+        "Host": "example.org",
+        "Cookie": ""
+      },
+      "request_query_parameters": {
+      },
+      "request_content_type": "application/vnd.api+json",
+      "response_status": 201,
+      "response_status_text": "Created",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"9\",\n    \"type\": \"lecturer\",\n    \"attributes\": {\n      \"created_at\": \"2019-02-27T06:43:21.643Z\",\n      \"updated_at\": \"2019-02-27T06:43:21.643Z\",\n      \"first_name\": \"Debera\",\n      \"last_name\": \"Bednar\",\n      \"patronymic\": \"Ms.\"\n    },\n    \"relationships\": {\n      \"courses\": {\n        \"data\": [\n          {\n            \"id\": \"10\",\n            \"type\": \"course\"\n          }\n        ]\n      }\n    }\n  }\n}",
+      "response_headers": {
+        "Page-Title": "El+Plano",
+        "X-Frame-Options": "DENY",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "Cache-Control": "max-age=0, private, must-revalidate, no-store",
+        "Pragma": "no-cache",
+        "Content-Type": "application/json; charset=utf-8",
+        "ETag": "W/\"68e5d75901745dc8ff5c69767bce1fc4\"",
+        "X-Request-Id": "e1fe45e6-6d2d-451a-a1d5-9d910c284df2",
+        "X-Runtime": "0.017594",
+        "Vary": "Origin",
+        "Content-Length": "261"
+      },
+      "response_content_type": "application/json; charset=utf-8",
+      "curl": "curl \"http://localhost:3000/api/v1/lecturers\" -d '{\"data\":{\"type\":\"lecturer\",\"attributes\":{\"first_name\":\"Debera\",\"last_name\":\"Bednar\",\"patronymic\":\"Ms.\"},\"relationships\":{\"courses\":{\"data\":[{\"id\":10,\"type\":\"courses\"}]}}}}' -X POST \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer e45dc1d6d25d621808e0dd4cdbd493064d2e997de09d4d1e8b8ef38c43ad6a39\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+    }
+  ]
+}

--- a/doc/api/lecturers/delete_:_delete_selected_lecturer.json
+++ b/doc/api/lecturers/delete_:_delete_selected_lecturer.json
@@ -1,0 +1,47 @@
+{
+  "resource": "Lecturers",
+  "resource_explanation": "El Plano lecturers API.\n\nCourse attributes :\n\n - `first_name`\n - `last_name`\n - `patronymic`\n - timestamps\n\n Also, includes reference to the courses.\n",
+  "http_method": "DELETE",
+  "route": "api/v1/lecturers/:id",
+  "description": "DELETE : Delete selected lecturer",
+  "explanation": "Delete lecturer.\n",
+  "parameters": [
+
+  ],
+  "response_fields": [
+
+  ],
+  "requests": [
+    {
+      "request_method": "DELETE",
+      "request_path": "api/v1/lecturers/11",
+      "request_body": null,
+      "request_headers": {
+        "Accept": "application/vnd.api+json",
+        "Content-Type": "application/vnd.api+json",
+        "Authorization": "Bearer 93f2d3256745c06f7b8a22ea97a7986497f47039eb8db28cf2c53e287c64c6ef",
+        "Host": "example.org",
+        "Cookie": ""
+      },
+      "request_query_parameters": {
+      },
+      "request_content_type": "application/vnd.api+json",
+      "response_status": 204,
+      "response_status_text": "No Content",
+      "response_body": null,
+      "response_headers": {
+        "Page-Title": "El+Plano",
+        "X-Frame-Options": "DENY",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "Cache-Control": "max-age=0, private, must-revalidate, no-store",
+        "Pragma": "no-cache",
+        "X-Request-Id": "63854ec6-e212-4594-b796-ad7996c12878",
+        "X-Runtime": "0.009061",
+        "Vary": "Origin"
+      },
+      "response_content_type": null,
+      "curl": "curl \"http://localhost:3000/api/v1/lecturers/11\" -d '' -X DELETE \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 93f2d3256745c06f7b8a22ea97a7986497f47039eb8db28cf2c53e287c64c6ef\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+    }
+  ]
+}

--- a/doc/api/lecturers/index_:_retrieve_lecturers_created_by_authenticated_user.json
+++ b/doc/api/lecturers/index_:_retrieve_lecturers_created_by_authenticated_user.json
@@ -1,0 +1,50 @@
+{
+  "resource": "Lecturers",
+  "resource_explanation": "El Plano lecturers API.\n\nCourse attributes :\n\n - `first_name`\n - `last_name`\n - `patronymic`\n - timestamps\n\n Also, includes reference to the courses.\n",
+  "http_method": "GET",
+  "route": "api/v1/lecturers",
+  "description": "INDEX : Retrieve lecturers created by authenticated user",
+  "explanation": "Return list of available lecturers.\n",
+  "parameters": [
+
+  ],
+  "response_fields": [
+
+  ],
+  "requests": [
+    {
+      "request_method": "GET",
+      "request_path": "api/v1/lecturers",
+      "request_body": null,
+      "request_headers": {
+        "Accept": "application/vnd.api+json",
+        "Content-Type": "application/vnd.api+json",
+        "Authorization": "Bearer e92b754bbafd7bffc8f1e0599aba1b9aee530f63b17070952d7e58c50f97d8b8",
+        "Host": "example.org",
+        "Cookie": ""
+      },
+      "request_query_parameters": {
+      },
+      "request_content_type": "application/vnd.api+json",
+      "response_status": 200,
+      "response_status_text": "OK",
+      "response_body": "{\n  \"data\": [\n    {\n      \"id\": \"7\",\n      \"type\": \"lecturer\",\n      \"attributes\": {\n        \"created_at\": \"2019-02-27T06:43:21.514Z\",\n        \"updated_at\": \"2019-02-27T06:43:21.514Z\",\n        \"first_name\": \"Ramon\",\n        \"last_name\": \"Gerlach\",\n        \"patronymic\": \"Jr.\"\n      },\n      \"relationships\": {\n        \"courses\": {\n          \"data\": [\n            {\n              \"id\": \"8\",\n              \"type\": \"course\"\n            }\n          ]\n        }\n      }\n    }\n  ]\n}",
+      "response_headers": {
+        "Page-Title": "El+Plano",
+        "X-Frame-Options": "DENY",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "Cache-Control": "max-age=0, private, must-revalidate, no-store",
+        "Pragma": "no-cache",
+        "Content-Type": "application/json; charset=utf-8",
+        "ETag": "W/\"ab42c78b2e8703f5575caca2ba26accb\"",
+        "X-Request-Id": "7ede7f9e-aac0-4226-9955-0c81332c1935",
+        "X-Runtime": "0.010698",
+        "Vary": "Origin",
+        "Content-Length": "262"
+      },
+      "response_content_type": "application/json; charset=utf-8",
+      "curl": "curl -g \"http://localhost:3000/api/v1/lecturers\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer e92b754bbafd7bffc8f1e0599aba1b9aee530f63b17070952d7e58c50f97d8b8\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+    }
+  ]
+}

--- a/doc/api/lecturers/show_:_retrieve_information_about_requested_lecturer.json
+++ b/doc/api/lecturers/show_:_retrieve_information_about_requested_lecturer.json
@@ -1,0 +1,50 @@
+{
+  "resource": "Lecturers",
+  "resource_explanation": "El Plano lecturers API.\n\nCourse attributes :\n\n - `first_name`\n - `last_name`\n - `patronymic`\n - timestamps\n\n Also, includes reference to the courses.\n",
+  "http_method": "GET",
+  "route": "api/v1/lecturers/:id",
+  "description": "SHOW : Retrieve information about requested lecturer",
+  "explanation": "Return single instance of the lecturer.\n",
+  "parameters": [
+
+  ],
+  "response_fields": [
+
+  ],
+  "requests": [
+    {
+      "request_method": "GET",
+      "request_path": "api/v1/lecturers/8",
+      "request_body": null,
+      "request_headers": {
+        "Accept": "application/vnd.api+json",
+        "Content-Type": "application/vnd.api+json",
+        "Authorization": "Bearer 86c67f0d3650dd9beb9b3b755ffa3d5ce8ac13190e5ca235c8c796dc7f066d03",
+        "Host": "example.org",
+        "Cookie": ""
+      },
+      "request_query_parameters": {
+      },
+      "request_content_type": "application/vnd.api+json",
+      "response_status": 200,
+      "response_status_text": "OK",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"8\",\n    \"type\": \"lecturer\",\n    \"attributes\": {\n      \"created_at\": \"2019-02-27T06:43:21.570Z\",\n      \"updated_at\": \"2019-02-27T06:43:21.570Z\",\n      \"first_name\": \"Lorette\",\n      \"last_name\": \"Corkery\",\n      \"patronymic\": \"Phd\"\n    },\n    \"relationships\": {\n      \"courses\": {\n        \"data\": [\n          {\n            \"id\": \"9\",\n            \"type\": \"course\"\n          }\n        ]\n      }\n    }\n  }\n}",
+      "response_headers": {
+        "Page-Title": "El+Plano",
+        "X-Frame-Options": "DENY",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "Cache-Control": "max-age=0, private, must-revalidate, no-store",
+        "Pragma": "no-cache",
+        "Content-Type": "application/json; charset=utf-8",
+        "ETag": "W/\"b93b12b956e8b69d43d293e026daf83e\"",
+        "X-Request-Id": "395b4199-a8a9-40b2-8ea3-17f9d1116838",
+        "X-Runtime": "0.008993",
+        "Vary": "Origin",
+        "Content-Length": "262"
+      },
+      "response_content_type": "application/json; charset=utf-8",
+      "curl": "curl -g \"http://localhost:3000/api/v1/lecturers/8\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 86c67f0d3650dd9beb9b3b755ffa3d5ce8ac13190e5ca235c8c796dc7f066d03\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+    }
+  ]
+}

--- a/doc/api/lecturers/update_:_update_selected_lecturer_information.json
+++ b/doc/api/lecturers/update_:_update_selected_lecturer_information.json
@@ -1,0 +1,84 @@
+{
+  "resource": "Lecturers",
+  "resource_explanation": "El Plano lecturers API.\n\nCourse attributes :\n\n - `first_name`\n - `last_name`\n - `patronymic`\n - timestamps\n\n Also, includes reference to the courses.\n",
+  "http_method": "PUT",
+  "route": "api/v1/lecturers/:id",
+  "description": "UPDATE : Update selected lecturer information",
+  "explanation": "Update and return updated lecturer.\n",
+  "parameters": [
+    {
+      "scope": [
+        "dta",
+        "attributes"
+      ],
+      "requred": true,
+      "name": "first_name",
+      "description": "Lecturer first name"
+    },
+    {
+      "scope": [
+        "dta",
+        "attributes"
+      ],
+      "requred": true,
+      "name": "last_name",
+      "description": "Lecturer last name"
+    },
+    {
+      "scope": [
+        "dta",
+        "attributes"
+      ],
+      "requred": true,
+      "name": "patronymic",
+      "description": "Lecturer patronymic"
+    },
+    {
+      "scope": [
+        "dta",
+        "attributes"
+      ],
+      "name": "courses",
+      "description": "Courses of the lecturer. Included in \"relationships\" category"
+    }
+  ],
+  "response_fields": [
+
+  ],
+  "requests": [
+    {
+      "request_method": "PUT",
+      "request_path": "api/v1/lecturers/10",
+      "request_body": "{\"data\":{\"type\":\"lecturer\",\"attributes\":{\"first_name\":\"Marva\",\"last_name\":\"Swaniawski\",\"patronymic\":\"Ms.\"},\"relationships\":{\"courses\":{\"data\":[{\"id\":12,\"type\":\"courses\"}]}}}}",
+      "request_headers": {
+        "Accept": "application/vnd.api+json",
+        "Content-Type": "application/vnd.api+json",
+        "Authorization": "Bearer ed400fa08215008ea567eb39a0a097deb52f437b5913070c7f381c7c6f72e57b",
+        "Host": "example.org",
+        "Cookie": ""
+      },
+      "request_query_parameters": {
+      },
+      "request_content_type": "application/vnd.api+json",
+      "response_status": 200,
+      "response_status_text": "OK",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"10\",\n    \"type\": \"lecturer\",\n    \"attributes\": {\n      \"created_at\": \"2019-02-27T06:43:21.672Z\",\n      \"updated_at\": \"2019-02-27T06:43:21.704Z\",\n      \"first_name\": \"Marva\",\n      \"last_name\": \"Swaniawski\",\n      \"patronymic\": \"Ms.\"\n    },\n    \"relationships\": {\n      \"courses\": {\n        \"data\": [\n          {\n            \"id\": \"12\",\n            \"type\": \"course\"\n          }\n        ]\n      }\n    }\n  }\n}",
+      "response_headers": {
+        "Page-Title": "El+Plano",
+        "X-Frame-Options": "DENY",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "Cache-Control": "max-age=0, private, must-revalidate, no-store",
+        "Pragma": "no-cache",
+        "Content-Type": "application/json; charset=utf-8",
+        "ETag": "W/\"ce87b23526e29977f26125b505535d9d\"",
+        "X-Request-Id": "4d1a711e-3309-496f-b8bf-54e7ad48425d",
+        "X-Runtime": "0.016764",
+        "Vary": "Origin",
+        "Content-Length": "265"
+      },
+      "response_content_type": "application/json; charset=utf-8",
+      "curl": "curl \"http://localhost:3000/api/v1/lecturers/10\" -d '{\"data\":{\"type\":\"lecturer\",\"attributes\":{\"first_name\":\"Marva\",\"last_name\":\"Swaniawski\",\"patronymic\":\"Ms.\"},\"relationships\":{\"courses\":{\"data\":[{\"id\":12,\"type\":\"courses\"}]}}}}' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer ed400fa08215008ea567eb39a0a097deb52f437b5913070c7f381c7c6f72e57b\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+    }
+  ]
+}

--- a/doc/api/students/show_:_retrieve_authenticated_users's_information.json
+++ b/doc/api/students/show_:_retrieve_authenticated_users's_information.json
@@ -19,7 +19,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 9efaf39b3252b7153e7a806ad22f1daf78d77623c91c46e0e6d0a74e616ba210",
+        "Authorization": "Bearer 57b827764aa8027697317a823c28c20ec162eb966dff220128d16c818ef17074",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -28,7 +28,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 200,
       "response_status_text": "OK",
-      "response_body": "{\n  \"data\": {\n    \"id\": \"34\",\n    \"type\": \"student\",\n    \"attributes\": {\n      \"full_name\": \"Ms. Agueda Audie Haag\",\n      \"email\": \"dorseyprice@huelshagenes.com\",\n      \"phone\": \"1-134-389-7803\",\n      \"about\": \"Occaecati odit culpa. Accusamus ex quaerat. Voluptatibus aut quo. Deserunt quasi facere. Aut dolores alias.\",\n      \"social_networks\": {\n        \"twitter\": \"http://twitter/lea\",\n        \"facebook\": \"http://facebook/columbus\"\n      },\n      \"president\": false,\n      \"created_at\": \"2019-02-27T06:08:48.950Z\",\n      \"updated_at\": \"2019-02-27T06:08:48.950Z\"\n    },\n    \"relationships\": {\n      \"group\": {\n        \"data\": {\n          \"id\": \"18\",\n          \"type\": \"group\"\n        }\n      },\n      \"user\": {\n        \"data\": {\n          \"id\": \"33\",\n          \"type\": \"user\"\n        }\n      }\n    }\n  }\n}",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"44\",\n    \"type\": \"student\",\n    \"attributes\": {\n      \"full_name\": \"Mr. Angel Carola Walker\",\n      \"email\": \"micahwindler@mcclure.net\",\n      \"phone\": \"544.367.7503\",\n      \"about\": \"Eligendi in sint. Sunt magnam praesentium. Modi doloribus quis. Quia aut voluptas. Magnam et qui.\",\n      \"social_networks\": {\n        \"twitter\": \"http://twitter/mahalia_mills\",\n        \"facebook\": \"http://facebook/gwendolyn\"\n      },\n      \"president\": false,\n      \"created_at\": \"2019-02-27T06:43:21.777Z\",\n      \"updated_at\": \"2019-02-27T06:43:21.777Z\"\n    },\n    \"relationships\": {\n      \"group\": {\n        \"data\": {\n          \"id\": \"28\",\n          \"type\": \"group\"\n        }\n      },\n      \"user\": {\n        \"data\": {\n          \"id\": \"43\",\n          \"type\": \"user\"\n        }\n      }\n    }\n  }\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -37,14 +37,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/json; charset=utf-8",
-        "ETag": "W/\"e2af7068d79752752e35d899cbf328d6\"",
-        "X-Request-Id": "92142798-b295-4e36-86a5-3f6b633dfbcc",
-        "X-Runtime": "0.005494",
+        "ETag": "W/\"16321b9485da791dca46a4905716fae2\"",
+        "X-Request-Id": "7b8577e7-d885-486d-8392-f6878ca3864b",
+        "X-Runtime": "0.007121",
         "Vary": "Origin",
-        "Content-Length": "561"
+        "Content-Length": "558"
       },
       "response_content_type": "application/json; charset=utf-8",
-      "curl": "curl -g \"http://localhost:3000/api/v1/student\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 9efaf39b3252b7153e7a806ad22f1daf78d77623c91c46e0e6d0a74e616ba210\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl -g \"http://localhost:3000/api/v1/student\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 57b827764aa8027697317a823c28c20ec162eb966dff220128d16c818ef17074\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/doc/api/students/update_:_updates_authenticated_user's_information.json
+++ b/doc/api/students/update_:_updates_authenticated_user's_information.json
@@ -58,7 +58,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer d72ae259d0307007ab0ec7759b451059157d3dbc22dbefb38d6c690d3cc4cd1a",
+        "Authorization": "Bearer f84fb5e3587c70aa1c6ce54baa2b8f4c4a65306f7d65570df6409a1c5b897a77",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -67,7 +67,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 200,
       "response_status_text": "OK",
-      "response_body": "{\n  \"data\": {\n    \"id\": \"36\",\n    \"type\": \"student\",\n    \"attributes\": {\n      \"full_name\": \"Sir Wat Name Yeah\",\n      \"email\": \"wat@wat.wat\",\n      \"phone\": \"+8 983 47 89 312\",\n      \"about\": \"Dolores cum veritatis. Ratione non reprehenderit. Ut dolor molestiae. Cupiditate voluptatum qui. Et occaecati autem.\",\n      \"social_networks\": {\n        \"twitter\": \"https://twitter.com/watever\",\n        \"facebook\": \"https://facebook.com/watever\"\n      },\n      \"president\": false,\n      \"created_at\": \"2019-02-27T06:08:48.977Z\",\n      \"updated_at\": \"2019-02-27T06:08:48.985Z\"\n    },\n    \"relationships\": {\n      \"group\": {\n        \"data\": {\n          \"id\": \"19\",\n          \"type\": \"group\"\n        }\n      },\n      \"user\": {\n        \"data\": {\n          \"id\": \"35\",\n          \"type\": \"user\"\n        }\n      }\n    }\n  }\n}",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"46\",\n    \"type\": \"student\",\n    \"attributes\": {\n      \"full_name\": \"Sir Wat Name Yeah\",\n      \"email\": \"wat@wat.wat\",\n      \"phone\": \"+8 983 47 89 312\",\n      \"about\": \"Doloremque saepe laudantium. Maxime necessitatibus amet. Tempore in et. Ad cumque rerum. Repellat veritatis et.\",\n      \"social_networks\": {\n        \"twitter\": \"https://twitter.com/watever\",\n        \"facebook\": \"https://facebook.com/watever\"\n      },\n      \"president\": false,\n      \"created_at\": \"2019-02-27T06:43:21.813Z\",\n      \"updated_at\": \"2019-02-27T06:43:21.823Z\"\n    },\n    \"relationships\": {\n      \"group\": {\n        \"data\": {\n          \"id\": \"29\",\n          \"type\": \"group\"\n        }\n      },\n      \"user\": {\n        \"data\": {\n          \"id\": \"45\",\n          \"type\": \"user\"\n        }\n      }\n    }\n  }\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -76,14 +76,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/json; charset=utf-8",
-        "ETag": "W/\"67db9224bbb13b073e2af9c6987c8f08\"",
-        "X-Request-Id": "12e7cc26-dcfc-4a01-985c-1a8443d89dad",
-        "X-Runtime": "0.006221",
+        "ETag": "W/\"20eee845058a6226f7a3dbf854f0fde3\"",
+        "X-Request-Id": "792568d7-9299-4f2d-9216-55cf3958e390",
+        "X-Runtime": "0.007751",
         "Vary": "Origin",
-        "Content-Length": "564"
+        "Content-Length": "559"
       },
       "response_content_type": "application/json; charset=utf-8",
-      "curl": "curl \"http://localhost:3000/api/v1/student\" -d '{\"data\":{\"type\":\"student\",\"attributes\":{\"email\":\"wat@wat.wat\",\"phone\":\"+8 983 47 89 312\",\"full_name\":\"Sir Wat Name Yeah\",\"social_networks\":{\"twitter\":\"https://twitter.com/watever\",\"facebook\":\"https://facebook.com/watever\"}}}}' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer d72ae259d0307007ab0ec7759b451059157d3dbc22dbefb38d6c690d3cc4cd1a\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000/api/v1/student\" -d '{\"data\":{\"type\":\"student\",\"attributes\":{\"email\":\"wat@wat.wat\",\"phone\":\"+8 983 47 89 312\",\"full_name\":\"Sir Wat Name Yeah\",\"social_networks\":{\"twitter\":\"https://twitter.com/watever\",\"facebook\":\"https://facebook.com/watever\"}}}}' -X PUT \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer f84fb5e3587c70aa1c6ce54baa2b8f4c4a65306f7d65570df6409a1c5b897a77\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/doc/api/user's_invites/index_:_retrieve_invites_for_authenticated_user.json
+++ b/doc/api/user's_invites/index_:_retrieve_invites_for_authenticated_user.json
@@ -19,7 +19,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 17d99d0fac7ae69e66f1d7209df0c2b567ff513d0518fe1a91587a05495ace4b",
+        "Authorization": "Bearer 075cfb0a0a0c71a609fedacd80508f6fc5a71f6133f49a8eb052a5ae7eb9f123",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -28,7 +28,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 200,
       "response_status_text": "OK",
-      "response_body": "{\n  \"data\": [\n    {\n      \"id\": \"4\",\n      \"type\": \"invite\",\n      \"attributes\": {\n        \"email\": \"gaston@lubowitzbeatty.io\",\n        \"invitation_token\": \"VDwWcxmAW6oZDahLrzLk\",\n        \"sent_at\": \"2019-02-27T06:08:48.842Z\",\n        \"accepted_at\": null,\n        \"created_at\": \"2019-02-27T06:08:48.842Z\",\n        \"updated_at\": \"2019-02-27T06:08:48.842Z\",\n        \"status\": \"pending\"\n      },\n      \"relationships\": {\n        \"sender\": {\n          \"data\": {\n            \"id\": \"25\",\n            \"type\": \"student\"\n          }\n        },\n        \"recipient\": {\n          \"data\": null\n        },\n        \"group\": {\n          \"data\": {\n            \"id\": \"15\",\n            \"type\": \"group\"\n          }\n        }\n      }\n    }\n  ]\n}",
+      "response_body": "{\n  \"data\": [\n    {\n      \"id\": \"4\",\n      \"type\": \"invite\",\n      \"attributes\": {\n        \"email\": \"lewis@rohan.biz\",\n        \"invitation_token\": \"nbsJvgfQhRhQpXs-y3R3\",\n        \"sent_at\": \"2019-02-27T06:43:21.381Z\",\n        \"accepted_at\": null,\n        \"created_at\": \"2019-02-27T06:43:21.381Z\",\n        \"updated_at\": \"2019-02-27T06:43:21.381Z\",\n        \"status\": \"pending\"\n      },\n      \"relationships\": {\n        \"sender\": {\n          \"data\": {\n            \"id\": \"30\",\n            \"type\": \"student\"\n          }\n        },\n        \"recipient\": {\n          \"data\": null\n        },\n        \"group\": {\n          \"data\": {\n            \"id\": \"20\",\n            \"type\": \"group\"\n          }\n        }\n      }\n    }\n  ]\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -37,14 +37,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/json; charset=utf-8",
-        "ETag": "W/\"9e1ac36cec5b46fe13b36702be92bb1b\"",
-        "X-Request-Id": "5a21b74a-8fba-4ce8-8bbe-7805754acb21",
-        "X-Runtime": "0.005482",
+        "ETag": "W/\"99934f05b0090921cde9d0051ae1958a\"",
+        "X-Request-Id": "70692050-1d73-4e5f-9323-878bef39a1b7",
+        "X-Runtime": "0.006767",
         "Vary": "Origin",
-        "Content-Length": "419"
+        "Content-Length": "410"
       },
       "response_content_type": "application/json; charset=utf-8",
-      "curl": "curl -g \"http://localhost:3000/api/v1/invites\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 17d99d0fac7ae69e66f1d7209df0c2b567ff513d0518fe1a91587a05495ace4b\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl -g \"http://localhost:3000/api/v1/invites\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 075cfb0a0a0c71a609fedacd80508f6fc5a71f6133f49a8eb052a5ae7eb9f123\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/doc/api/user's_invites/show_:_retrieve_information_about_requested_invite.json
+++ b/doc/api/user's_invites/show_:_retrieve_information_about_requested_invite.json
@@ -14,12 +14,12 @@
   "requests": [
     {
       "request_method": "GET",
-      "request_path": "api/v1/invites/zhwjYXrQy17yL-dxENB4",
+      "request_path": "api/v1/invites/zwZyxLAQgSy2bYC1cyjd",
       "request_body": null,
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 3364d47bcebfaee7378d2301e3c011ac51fc11d60f47d700d4833e901f1cc3c8",
+        "Authorization": "Bearer db9ee30a63a995f18326b9e33a675228b0422f44aed94c2a3959836d036297f7",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -28,7 +28,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 200,
       "response_status_text": "OK",
-      "response_body": "{\n  \"data\": {\n    \"id\": \"5\",\n    \"type\": \"invite\",\n    \"attributes\": {\n      \"email\": \"ashleylockman@price.name\",\n      \"invitation_token\": \"zhwjYXrQy17yL-dxENB4\",\n      \"sent_at\": \"2019-02-27T06:08:48.879Z\",\n      \"accepted_at\": null,\n      \"created_at\": \"2019-02-27T06:08:48.879Z\",\n      \"updated_at\": \"2019-02-27T06:08:48.879Z\",\n      \"status\": \"pending\"\n    },\n    \"relationships\": {\n      \"sender\": {\n        \"data\": {\n          \"id\": \"28\",\n          \"type\": \"student\"\n        }\n      },\n      \"recipient\": {\n        \"data\": null\n      },\n      \"group\": {\n        \"data\": {\n          \"id\": \"16\",\n          \"type\": \"group\"\n        }\n      }\n    }\n  },\n  \"included\": [\n    {\n      \"id\": \"16\",\n      \"type\": \"group\",\n      \"attributes\": {\n        \"number\": \"1279141571\",\n        \"title\": \"Ea ea doloremque.\",\n        \"created_at\": \"2019-02-27T06:08:48.876Z\",\n        \"updated_at\": \"2019-02-27T06:08:48.876Z\"\n      },\n      \"relationships\": {\n      }\n    }\n  ]\n}",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"5\",\n    \"type\": \"invite\",\n    \"attributes\": {\n      \"email\": \"salvador@macejkovic.net\",\n      \"invitation_token\": \"zwZyxLAQgSy2bYC1cyjd\",\n      \"sent_at\": \"2019-02-27T06:43:21.429Z\",\n      \"accepted_at\": null,\n      \"created_at\": \"2019-02-27T06:43:21.429Z\",\n      \"updated_at\": \"2019-02-27T06:43:21.429Z\",\n      \"status\": \"pending\"\n    },\n    \"relationships\": {\n      \"sender\": {\n        \"data\": {\n          \"id\": \"33\",\n          \"type\": \"student\"\n        }\n      },\n      \"recipient\": {\n        \"data\": null\n      },\n      \"group\": {\n        \"data\": {\n          \"id\": \"21\",\n          \"type\": \"group\"\n        }\n      }\n    }\n  },\n  \"included\": [\n    {\n      \"id\": \"21\",\n      \"type\": \"group\",\n      \"attributes\": {\n        \"number\": \"9778133480\",\n        \"title\": \"Cumque odit voluptas.\",\n        \"created_at\": \"2019-02-27T06:43:21.425Z\",\n        \"updated_at\": \"2019-02-27T06:43:21.425Z\"\n      },\n      \"relationships\": {\n      }\n    }\n  ]\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -37,14 +37,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/json; charset=utf-8",
-        "ETag": "W/\"5f6fe3ff2e2670f91b747b90c0b802f0\"",
-        "X-Request-Id": "91f18871-298d-4c98-9560-84e546405150",
-        "X-Runtime": "0.005060",
+        "ETag": "W/\"81f8050df319da5656db0b2d4056369e\"",
+        "X-Request-Id": "d5748e29-adac-4a38-acd8-1b36cde9f140",
+        "X-Runtime": "0.006648",
         "Vary": "Origin",
-        "Content-Length": "621"
+        "Content-Length": "624"
       },
       "response_content_type": "application/json; charset=utf-8",
-      "curl": "curl -g \"http://localhost:3000/api/v1/invites/zhwjYXrQy17yL-dxENB4\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 3364d47bcebfaee7378d2301e3c011ac51fc11d60f47d700d4833e901f1cc3c8\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl -g \"http://localhost:3000/api/v1/invites/zwZyxLAQgSy2bYC1cyjd\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer db9ee30a63a995f18326b9e33a675228b0422f44aed94c2a3959836d036297f7\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/doc/api/user's_invites/update_:_accept_selected_invite.json
+++ b/doc/api/user's_invites/update_:_accept_selected_invite.json
@@ -14,12 +14,12 @@
   "requests": [
     {
       "request_method": "PATCH",
-      "request_path": "api/v1/invites/Z4c9hnmVqUHgGn_GboUA",
+      "request_path": "api/v1/invites/yf5XQNAYsiiHYA5gKDxh",
       "request_body": null,
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer 3065826faccd491481db1d8b5697a0bf7a8934208a3fca8d572d217b20d2c660",
+        "Authorization": "Bearer 87fa3198cc4a9c1b9302bd010bd1edfdca28e1aa1412d7f425fac5e228558a86",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -28,7 +28,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 200,
       "response_status_text": "OK",
-      "response_body": "{\n  \"data\": {\n    \"id\": \"6\",\n    \"type\": \"invite\",\n    \"attributes\": {\n      \"email\": \"diego@wuckert.biz\",\n      \"invitation_token\": null,\n      \"sent_at\": \"2019-02-27T06:08:48.918Z\",\n      \"accepted_at\": \"2019-02-27T06:08:48.926Z\",\n      \"created_at\": \"2019-02-27T06:08:48.918Z\",\n      \"updated_at\": \"2019-02-27T06:08:48.929Z\",\n      \"status\": \"accepted\"\n    },\n    \"relationships\": {\n      \"sender\": {\n        \"data\": {\n          \"id\": \"31\",\n          \"type\": \"student\"\n        }\n      },\n      \"recipient\": {\n        \"data\": {\n          \"id\": \"30\",\n          \"type\": \"student\"\n        }\n      },\n      \"group\": {\n        \"data\": {\n          \"id\": \"17\",\n          \"type\": \"group\"\n        }\n      }\n    }\n  }\n}",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"6\",\n    \"type\": \"invite\",\n    \"attributes\": {\n      \"email\": \"susannwolff@mclaughlin.io\",\n      \"invitation_token\": null,\n      \"sent_at\": \"2019-02-27T06:43:21.478Z\",\n      \"accepted_at\": \"2019-02-27T06:43:21.488Z\",\n      \"created_at\": \"2019-02-27T06:43:21.477Z\",\n      \"updated_at\": \"2019-02-27T06:43:21.491Z\",\n      \"status\": \"accepted\"\n    },\n    \"relationships\": {\n      \"sender\": {\n        \"data\": {\n          \"id\": \"36\",\n          \"type\": \"student\"\n        }\n      },\n      \"recipient\": {\n        \"data\": {\n          \"id\": \"35\",\n          \"type\": \"student\"\n        }\n      },\n      \"group\": {\n        \"data\": {\n          \"id\": \"22\",\n          \"type\": \"group\"\n        }\n      }\n    }\n  }\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -37,14 +37,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/json; charset=utf-8",
-        "ETag": "W/\"01e93581d6385370572b80e55f710de1\"",
-        "X-Request-Id": "83900935-53e0-4c3d-b345-803171745411",
-        "X-Runtime": "0.010283",
+        "ETag": "W/\"277d249ea462e90161f4b6f3bd80daab\"",
+        "X-Request-Id": "81be3679-a2fd-421f-adac-7db67552357b",
+        "X-Runtime": "0.012764",
         "Vary": "Origin",
-        "Content-Length": "439"
+        "Content-Length": "447"
       },
       "response_content_type": "application/json; charset=utf-8",
-      "curl": "curl \"http://localhost:3000/api/v1/invites/Z4c9hnmVqUHgGn_GboUA\" -d '' -X PATCH \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 3065826faccd491481db1d8b5697a0bf7a8934208a3fca8d572d217b20d2c660\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl \"http://localhost:3000/api/v1/invites/yf5XQNAYsiiHYA5gKDxh\" -d '' -X PATCH \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 87fa3198cc4a9c1b9302bd010bd1edfdca28e1aa1412d7f425fac5e228558a86\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/doc/api/users/show_:_retrieve_authenticated_users's_profile.json
+++ b/doc/api/users/show_:_retrieve_authenticated_users's_profile.json
@@ -19,7 +19,7 @@
       "request_headers": {
         "Accept": "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
-        "Authorization": "Bearer f1e7af68ec80144883692f84c905ac336cec597cc283f5451245306eddd449ea",
+        "Authorization": "Bearer 1889a1c88e9bdba7ff6fbaea8e3b9a2ef1c55d671db6bc44d264e96f9ec62d39",
         "Host": "example.org",
         "Cookie": ""
       },
@@ -28,7 +28,7 @@
       "request_content_type": "application/vnd.api+json",
       "response_status": 200,
       "response_status_text": "OK",
-      "response_body": "{\n  \"data\": {\n    \"id\": \"37\",\n    \"type\": \"user\",\n    \"attributes\": {\n      \"email\": \"albertina@hermistonmurazik.info\",\n      \"username\": \"adina_gutmann\",\n      \"admin\": false,\n      \"created_at\": \"2019-02-27T06:08:48.994Z\",\n      \"updated_at\": \"2019-02-27T06:08:48.994Z\",\n      \"avatar_url\": \"https://www.gravatar.com/avatar/ce258fa85c998d601c92dbaafacd0305?s=200&d=identicon\",\n      \"confirmed\": true\n    },\n    \"relationships\": {\n      \"student\": {\n        \"data\": {\n          \"id\": \"37\",\n          \"type\": \"student\"\n        }\n      }\n    }\n  }\n}",
+      "response_body": "{\n  \"data\": {\n    \"id\": \"47\",\n    \"type\": \"user\",\n    \"attributes\": {\n      \"email\": \"audie@wiegand.co\",\n      \"username\": \"stewart\",\n      \"admin\": false,\n      \"created_at\": \"2019-02-27T06:43:21.834Z\",\n      \"updated_at\": \"2019-02-27T06:43:21.834Z\",\n      \"avatar_url\": \"https://www.gravatar.com/avatar/433d13f94eb2660f0d29d4ba95216bd2?s=200&d=identicon\",\n      \"confirmed\": true\n    },\n    \"relationships\": {\n      \"student\": {\n        \"data\": {\n          \"id\": \"47\",\n          \"type\": \"student\"\n        }\n      }\n    }\n  }\n}",
       "response_headers": {
         "Page-Title": "El+Plano",
         "X-Frame-Options": "DENY",
@@ -37,14 +37,14 @@
         "Cache-Control": "max-age=0, private, must-revalidate, no-store",
         "Pragma": "no-cache",
         "Content-Type": "application/json; charset=utf-8",
-        "ETag": "W/\"c5ddbbaf22d74a35309aa360dca8ff46\"",
-        "X-Request-Id": "34395701-ed1c-48b5-b73b-98fcc222fb2b",
-        "X-Runtime": "0.006065",
+        "ETag": "W/\"f7a1dc166ecc1f0b3487ea80aa0531c6\"",
+        "X-Request-Id": "5b94a35c-a7ef-47d7-a9e5-5337917faf5d",
+        "X-Runtime": "0.009473",
         "Vary": "Origin",
-        "Content-Length": "398"
+        "Content-Length": "377"
       },
       "response_content_type": "application/json; charset=utf-8",
-      "curl": "curl -g \"http://localhost:3000/api/v1/user\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer f1e7af68ec80144883692f84c905ac336cec597cc283f5451245306eddd449ea\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
+      "curl": "curl -g \"http://localhost:3000/api/v1/user\" -X GET \\\n\t-H \"Accept: application/vnd.api+json\" \\\n\t-H \"Content-Type: application/vnd.api+json\" \\\n\t-H \"Authorization: Bearer 1889a1c88e9bdba7ff6fbaea8e3b9a2ef1c55d671db6bc44d264e96f9ec62d39\" \\\n\t-H \"Host: example.org\" \\\n\t-H \"Cookie: \""
     }
   ]
 }

--- a/spec/acceptance/api/v1/courses_spec.rb
+++ b/spec/acceptance/api/v1/courses_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require 'acceptance_helper'
+
+resource 'Courses' do
+  explanation <<~DESC
+    El Plano courses API.
+
+    Course attributes :
+
+     - `title` - Represents course name(human readable identity).
+     - timestamps
+  
+     Also, includes reference to the course lecturer.
+  DESC
+
+  let(:student) { create(:student, :group_supervisor) }
+
+  let(:user) { student.user }
+  let(:token) { create(:token, resource_owner_id: user.id).token }
+  let(:authorization) { "Bearer #{token}" }
+
+  let(:lecturer) { create(:lecturer, group: student.group) }
+  let(:group)  { student.group }
+  let(:course) { create(:course, :with_lecturers, group: group) }
+  let(:id) { course.id }
+
+  header 'Accept',        'application/vnd.api+json'
+  header 'Content-Type',  'application/vnd.api+json'
+  header 'Authorization', :authorization
+
+  get 'api/v1/courses' do
+    let!(:courses) { create_list(:course, 1, :with_lecturers, group: group) }
+
+    example 'INDEX : Retrieve courses created by authenticated user' do
+      explanation <<~DESC
+        Return list of available courses.
+      DESC
+
+      do_request
+
+      expected_body = CourseSerializer.new(group.courses).serialized_json.to_s
+
+      expect(status).to eq(200)
+      expect(response_body).to eq(expected_body)
+    end
+  end
+
+  get 'api/v1/courses/:id' do
+    example 'SHOW : Retrieve information about requested course' do
+      explanation <<~DESC
+        Return single instance of the course.
+      DESC
+
+      do_request
+
+      expected_body = CourseSerializer.new(course).serialized_json.to_s
+
+      expect(status).to eq(200)
+      expect(response_body).to eq(expected_body)
+    end
+  end
+
+  post 'api/v1/courses' do
+    with_options scope: %i[dta attributes] do
+      parameter :title, 'Course title(human readable identity)', requred: true
+      parameter :lecturers, 'Lecturers of the course. Included in "relationships" category'
+    end
+
+    let(:raw_post) do
+      lecturer_params = {
+        relationships: {
+          lecturers: {
+            data: [{ id: lecturer.id, type: 'lecturer' }]
+          }
+        }
+      }
+
+      { data: build(:course_params).merge(lecturer_params) }.to_json
+    end
+
+    example 'CREATE : Create new course' do
+      explanation <<~DESC
+        Create and return created course.
+      DESC
+
+      do_request
+
+      expected_body = CourseSerializer.new(group.courses.last).serialized_json.to_s
+
+      expect(status).to eq(201)
+      expect(response_body).to eq(expected_body)
+    end
+  end
+
+  put 'api/v1/courses/:id' do
+    with_options scope: %i[data attributes] do
+      parameter :title, 'Course title(human readable identity)', requred: true
+      parameter :lecturers, 'Lecturers of the course. Included in "relationships" category'
+    end
+
+    let(:raw_post) do
+      lecturer_params = {
+        relationships: {
+          lecturers: {
+            data: [{ id: lecturer.id, type: 'lecturer' }]
+          }
+        }
+      }
+
+      { data: build(:course_params).merge(lecturer_params) }.to_json
+    end
+
+    example 'UPDATE : Update selected course information' do
+      explanation <<~DESC
+        Update and return updated course.
+      DESC
+
+      do_request
+
+      expected_body = CourseSerializer.new(course.reload).serialized_json.to_s
+
+      expect(status).to eq(200)
+      expect(response_body).to eq(expected_body)
+    end
+  end
+
+  delete 'api/v1/courses/:id' do
+    example 'DELETE : Delete selected course' do
+      explanation <<~DESC
+        Delete course.
+      DESC
+
+      do_request
+
+      expect(status).to eq(204)
+    end
+  end
+end

--- a/spec/acceptance/api/v1/events_spec.rb
+++ b/spec/acceptance/api/v1/events_spec.rb
@@ -21,10 +21,11 @@ resource 'Events' do
      - `end_at` - Represents when event ends.
      - timestamps
   
-     Also, includes reference to the event creator.
+     Also, includes reference to the event creator and attached course.
   DESC
 
   let(:student) { create(:student, :group_member) }
+  let(:course) { create(:course, group: student.group) }
 
   let(:user) { student.user }
   let(:token) { create(:token, resource_owner_id: user.id).token }
@@ -78,9 +79,20 @@ resource 'Events' do
       parameter :start_at, 'Event start date', requred: true
       parameter :end_at, 'Event end date', requred: true
       parameter :timezone, 'Event timezone', requred: true
+      parameter :course, 'The course to which the event is attached. Included in "relationships" category'
     end
 
-    let(:raw_post) { { data: build(:event_params) }.to_json }
+    let(:raw_post) do
+      course_params = {
+        relationships: {
+          course: {
+            data: { id: course.id, type: 'course' }
+          }
+        }
+      }
+
+      { data: build(:event_params).merge(course_params) }.to_json
+    end
 
     example 'CREATE : Creates new event' do
       explanation <<~DESC
@@ -108,9 +120,20 @@ resource 'Events' do
       parameter :start_at, 'Event start date', requred: true
       parameter :end_at, 'Event end date', requred: true
       parameter :timezone, 'Event timezone', requred: true
+      parameter :course, 'The course to which the event is attached. Included in "relationships" category'
     end
 
-    let(:raw_post) { { data: build(:event_params) }.to_json }
+    let(:raw_post) do
+      course_params = {
+        relationships: {
+          course: {
+            data: { id: course.id, type: 'course' }
+          }
+        }
+      }
+
+      { data: build(:event_params).merge(course_params) }.to_json
+    end
 
     example 'UPDATE : Updates selected event information' do
       explanation <<~DESC

--- a/spec/acceptance/api/v1/lecturers_spec.rb
+++ b/spec/acceptance/api/v1/lecturers_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'acceptance_helper'
+
+resource 'Lecturers' do
+  explanation <<~DESC
+    El Plano lecturers API.
+
+    Course attributes :
+
+     - `first_name`
+     - `last_name`
+     - `patronymic`
+     - timestamps
+  
+     Also, includes reference to the courses.
+  DESC
+
+  let(:student) { create(:student, :group_supervisor) }
+
+  let(:user) { student.user }
+  let(:token) { create(:token, resource_owner_id: user.id).token }
+  let(:authorization) { "Bearer #{token}" }
+
+  let(:course) { create(:course, group: student.group) }
+  let(:group)  { student.group }
+  let(:lecturer) { create(:lecturer, :with_courses, group: group) }
+  let(:id) { lecturer.id }
+
+  header 'Accept',        'application/vnd.api+json'
+  header 'Content-Type',  'application/vnd.api+json'
+  header 'Authorization', :authorization
+
+  get 'api/v1/lecturers' do
+    let!(:lecturers) { create_list(:lecturer, 1, :with_courses, group: group) }
+
+    example 'INDEX : Retrieve lecturers created by authenticated user' do
+      explanation <<~DESC
+        Return list of available lecturers.
+      DESC
+
+      do_request
+
+      expected_body = LecturerSerializer.new(group.lecturers).serialized_json.to_s
+
+      expect(status).to eq(200)
+      expect(response_body).to eq(expected_body)
+    end
+  end
+
+  get 'api/v1/lecturers/:id' do
+    example 'SHOW : Retrieve information about requested lecturer' do
+      explanation <<~DESC
+        Return single instance of the lecturer.
+      DESC
+
+      do_request
+
+      expected_body = LecturerSerializer.new(lecturer).serialized_json.to_s
+
+      expect(status).to eq(200)
+      expect(response_body).to eq(expected_body)
+    end
+  end
+
+  post 'api/v1/lecturers' do
+    with_options scope: %i[dta attributes] do
+      parameter :first_name, 'Lecturer first name', requred: true
+      parameter :last_name, 'Lecturer last name', requred: true
+      parameter :patronymic, 'Lecturer patronymic', requred: true
+      parameter :courses, 'Courses of the lecturer. Included in "relationships" category'
+    end
+
+    let(:raw_post) do
+      course_params = {
+        relationships: {
+          courses: {
+            data: [{ id: course.id, type: 'courses' }]
+          }
+        }
+      }
+
+      { data: build(:lecturer_params).merge(course_params) }.to_json
+    end
+
+    example 'CREATE : Create new lecturer' do
+      explanation <<~DESC
+        Create and return created lecturer.
+      DESC
+
+      do_request
+
+      expected_body = LecturerSerializer.new(group.lecturers.last).serialized_json.to_s
+
+      expect(status).to eq(201)
+      expect(response_body).to eq(expected_body)
+    end
+  end
+
+  put 'api/v1/lecturers/:id' do
+    with_options scope: %i[dta attributes] do
+      parameter :first_name, 'Lecturer first name', requred: true
+      parameter :last_name, 'Lecturer last name', requred: true
+      parameter :patronymic, 'Lecturer patronymic', requred: true
+      parameter :courses, 'Courses of the lecturer. Included in "relationships" category'
+    end
+
+    let(:raw_post) do
+      course_params = {
+        relationships: {
+          courses: {
+            data: [{ id: course.id, type: 'courses' }]
+          }
+        }
+      }
+
+      { data: build(:lecturer_params).merge(course_params) }.to_json
+    end
+
+    example 'UPDATE : Update selected lecturer information' do
+      explanation <<~DESC
+        Update and return updated lecturer.
+      DESC
+
+      do_request
+
+      expected_body = LecturerSerializer.new(lecturer.reload).serialized_json.to_s
+
+      expect(status).to eq(200)
+      expect(response_body).to eq(expected_body)
+    end
+  end
+
+  delete 'api/v1/lecturers/:id' do
+    example 'DELETE : Delete selected lecturer' do
+      explanation <<~DESC
+        Delete lecturer.
+      DESC
+
+      do_request
+
+      expect(status).to eq(204)
+    end
+  end
+end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :course, class: Course do
+    title  { Faker::Lorem.sentence(2) }
+
+    group
+
+    trait :with_lecturers do
+      after(:create) do |course, _|
+        course.update!(lecturers: create_list(:lecturer, 1, group: course.group))
+      end
+    end
+  end
+
+  factory :course_params, class: Hash do
+    initialize_with do
+      {
+        type: 'course',
+        attributes: {
+          title: Faker::Educator.course,
+        }
+      }
+    end
+  end
+
+  factory :invalid_course_params, class: Hash do
+    initialize_with do
+      {
+        type: 'course',
+        attributes: {
+          title: nil
+        }
+      }
+    end
+  end
+end

--- a/spec/factories/lecturers.rb
+++ b/spec/factories/lecturers.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :lecturer, class: Lecturer do
+    first_name  { Faker::Name.first_name }
+    last_name   { Faker::Name.last_name }
+    patronymic  { Faker::Name.suffix }
+
+    group
+
+    trait :with_courses do
+      after(:create) do |lecturer, _|
+        lecturer.update!(courses: create_list(:course, 1, group: lecturer.group))
+      end
+    end
+  end
+
+  factory :lecturer_params, class: Hash do
+    initialize_with do
+      {
+        type: 'lecturer',
+        attributes: {
+          first_name: Faker::Name.first_name,
+          last_name: Faker::Name.last_name,
+          patronymic: Faker::Name.prefix
+        }
+      }
+    end
+  end
+
+  factory :invalid_lecturer_params, class: Hash do
+    initialize_with do
+      {
+        type: 'lecturer',
+        attributes: {
+          first_name: nil,
+          last_name: "",
+          patronymic: Faker::Lorem.sentence(20)
+        }
+      }
+    end
+  end
+end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Course, type: :model do
+  describe 'associations' do
+    it { should belong_to(:group) }
+
+    it { should have_many(:lectures).dependent(:delete_all) }
+
+    it { should have_many(:lecturers).through(:lectures) }
+
+    it { should have_many(:events).dependent(:nullify) }
+  end
+
+  describe 'validations' do
+    subject { create(:course) }
+
+    it { should validate_presence_of(:title) }
+
+    it { should validate_length_of(:title).is_at_most(200) }
+
+    it do
+      should validate_uniqueness_of(:title).scoped_to(%i[group_id]).case_insensitive
+    end
+  end
+
+  context 'callbacks' do
+    describe 'before_validation' do
+      let_it_be(:subject) do
+        create(:course, title: 'lOoK MA DiFFeReNt_CasE')
+      end
+
+      it { expect(subject.title).to eq('look ma different_case') }
+    end
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe Event, type: :model do
   describe 'associations' do
     it { should belong_to(:creator).class_name('Student') }
+
+    it { should belong_to(:course).optional }
   end
 
   describe 'validations' do

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Group, type: :model do
 
     it { should have_many(:students).dependent(:nullify) }
 
-    it { should have_many(:invites) }
+    it { should have_many(:invites).dependent(:destroy) }
+
+    it { should have_many(:lecturers).dependent(:destroy) }
   end
 
   describe 'validations' do

--- a/spec/models/lecture_spec.rb
+++ b/spec/models/lecture_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Lecture, type: :model do
+  describe 'associations' do
+    it { should belong_to(:lecturer) }
+
+    it { should belong_to(:course) }
+  end
+end

--- a/spec/models/lecturer_spec.rb
+++ b/spec/models/lecturer_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe Lecturer, type: :model do
+  describe 'associations' do
+    it { should belong_to(:group) }
+
+    it { should have_many(:lectures).dependent(:delete_all) }
+
+    it { should have_many(:courses).through(:lectures) }
+  end
+
+  describe 'validations' do
+    subject { create(:lecturer) }
+
+    it { should validate_presence_of(:first_name) }
+
+    it { should validate_presence_of(:last_name) }
+
+    it { should validate_presence_of(:patronymic) }
+
+    it { should validate_length_of(:first_name).is_at_most(40) }
+
+    it { should validate_length_of(:last_name).is_at_most(40) }
+
+    it { should validate_length_of(:patronymic).is_at_most(40) }
+
+    it do
+      should validate_uniqueness_of(:group_id)
+               .scoped_to(%i[first_name last_name patronymic])
+               .case_insensitive
+    end
+  end
+
+  context 'callbacks' do
+    describe 'before_validation' do
+      let_it_be(:subject) do
+        create(:lecturer, first_name: 'lOoK', last_name: 'MA', patronymic: 'DiFFeReNt_CasE')
+      end
+
+      it { expect(subject.first_name).to eq('look') }
+
+      it { expect(subject.last_name).to eq('ma') }
+
+      it { expect(subject.patronymic).to eq('different_case') }
+    end
+  end
+end

--- a/spec/requests/api/v1/courses_spec.rb
+++ b/spec/requests/api/v1/courses_spec.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Courses management', type: :request do
+  include_context 'shared setup'
+
+  let(:base_endpoint)     { '/api/v1/courses' }
+  let(:resource_endpoint) { "#{base_endpoint}/#{course.id}" }
+
+  let_it_be(:student) { create(:student, :group_supervisor, user: user) }
+  let_it_be(:course)  { create(:course, title: 'some new course', group: student.group) }
+
+  let(:course_params)  { build(:course_params) }
+
+  let(:request_params) { { data: course_params } }
+  let(:invalid_request_params) { { data: build(:invalid_course_params) } }
+
+  describe 'GET #index' do
+    subject { get base_endpoint, headers: headers }
+
+    let_it_be(:courses) { create_list(:course, 4, group: student.group) }
+
+    context 'N+1' do
+      bulletify { subject }
+    end
+
+    context 'unsorted courses collection' do
+      before(:each) { subject }
+
+      it 'responds with a 200 status' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns correct quantity' do
+        expect(JSON.parse(response.body)['data'].count).to be(5)
+      end
+    end
+  end
+
+  describe 'GET #show' do
+    subject { get resource_endpoint, headers: headers }
+
+    before(:each) { subject }
+
+    it 'responds with a 200 status' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    include_examples 'json:api examples',
+                     %w[data],
+                     %w[id type attributes relationships],
+                     %w[title created_at updated_at],
+                     %w[lecturers]
+
+    it 'returns correct expected data' do
+      actual_title = body_as_json[:data][:attributes][:title].downcase
+      expected_title = course.title
+
+      expect(actual_title).to eq(expected_title)
+    end
+
+    context 'not valid request' do
+      let(:resource_endpoint) { "#{base_endpoint}/wat_course?" }
+
+      it 'returns 404 response on not existed course' do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    subject { post base_endpoint, params: request_params, headers: headers }
+
+    before(:each) { subject }
+
+    context 'group owner' do
+      it 'responds with a 201 status' do
+        expect(response).to have_http_status(:created)
+      end
+
+      include_examples 'json:api examples',
+                       %w[data],
+                       %w[id type attributes relationships],
+                       %w[title created_at updated_at],
+                       %w[lecturers]
+
+      it 'returns created model' do
+        actual_title = body_as_json[:data][:attributes][:title].downcase
+        expected_title = course_params[:attributes][:title].downcase
+
+        expect(actual_title).to eq(expected_title)
+      end
+
+      context 'lecturer binding' do
+        let_it_be(:lecturer) { create(:lecturer, group: student.group) }
+
+        let(:course_params) do
+          lecturer_params = {
+            relationships: {
+              lecturers: {
+                data: [{ id: lecturer.id, type: 'lecturer' }]
+              }
+            }
+          }
+
+          build(:course_params).merge(lecturer_params)
+        end
+
+        it 'return created model with bound lecturer' do
+          actual_lecturer_ids = relationship_data(:lecturers).map { |l| l[:id].to_i }
+
+          expect(actual_lecturer_ids).to include(lecturer.id)
+        end
+      end
+
+      include_examples 'request errors examples'
+    end
+
+    context 'regular group member' do
+      let_it_be(:student) { create(:student, :group_member, user: user) }
+
+      it 'responds with 403 - forbidden' do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe 'PUT #update' do
+    subject { put resource_endpoint, params: request_params, headers: headers }
+
+    before(:each) { subject }
+
+    context 'group owner' do
+      it 'responds with a 200 status' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'updates a course model' do
+        actual_title = course.reload.title
+        expected_title = course_params[:attributes][:title].downcase
+
+        expect(actual_title).to eq(expected_title)
+      end
+
+      include_examples 'json:api examples',
+                       %w[data],
+                       %w[id type attributes relationships],
+                       %w[title created_at updated_at],
+                       %w[lecturers]
+
+      include_examples 'request errors examples'
+
+      context 'lecturer binding' do
+        let_it_be(:lecturer) { create(:lecturer, group: student.group) }
+
+        let(:course_params) do
+          lecturer_params = {
+            relationships: {
+              lecturers: {
+                data: [{ id: lecturer.id, type: 'lecturer' }]
+              }
+            }
+          }
+
+          build(:course_params).merge(lecturer_params)
+        end
+
+        it 'return created model with bound lecturer' do
+          actual_lecturer_ids = relationship_data(:lecturers).map { |l| l[:id].to_i }
+
+          expect(actual_lecturer_ids).to include(lecturer.id)
+        end
+      end
+
+      context 'response with errors' do
+        let(:resource_endpoint) { "#{base_endpoint}/wat_course?" }
+
+        it 'responds with a 404 status not existed course' do
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
+    context 'regular group member' do
+      let_it_be(:student) { create(:student, :group_member, user: user) }
+
+      it 'responds with 403 - forbidden' do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    context 'group owner' do
+      it 'responds with a 204 status' do
+        delete resource_endpoint, headers: headers
+
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it 'responds with a 404 status not existed course' do
+        delete "#{base_endpoint}/wat_course?", headers: headers
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'deletes publisher' do
+        expect { delete resource_endpoint, headers: headers }.to change(Course, :count).by(-1)
+      end
+    end
+
+    context 'regular group member' do
+      let_it_be(:student) { create(:student, :group_member, user: user) }
+
+      it 'responds with 403 - forbidden' do
+        delete resource_endpoint, headers: headers
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/lecturers_spec.rb
+++ b/spec/requests/api/v1/lecturers_spec.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Lecturers management', type: :request do
+  include_context 'shared setup'
+
+  let(:base_endpoint)     { '/api/v1/lecturers' }
+  let(:resource_endpoint) { "#{base_endpoint}/#{lecturer.id}" }
+
+  let_it_be(:student) { create(:student, :group_supervisor, user: user) }
+  let_it_be(:lecturer)  { create(:lecturer, group: student.group) }
+
+  let(:lecturer_params)  { build(:lecturer_params) }
+
+  let(:request_params) { { data: lecturer_params } }
+  let(:invalid_request_params) { { data: build(:invalid_lecturer_params) } }
+
+  describe 'GET #index' do
+    subject { get base_endpoint, headers: headers }
+
+    let_it_be(:lecturers) { create_list(:lecturer, 4, group: student.group) }
+
+    context 'N+1' do
+      bulletify { subject }
+    end
+
+    context 'unsorted lecturers collection' do
+      before(:each) { subject }
+
+      it 'responds with a 200 status' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns correct quantity' do
+        expect(JSON.parse(response.body)['data'].count).to be(5)
+      end
+    end
+  end
+
+  describe 'GET #show' do
+    subject { get resource_endpoint, headers: headers }
+
+    before(:each) { subject }
+
+    it 'responds with a 200 status' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    include_examples 'json:api examples',
+                     %w[data],
+                     %w[id type attributes relationships],
+                     %w[first_name last_name patronymic created_at updated_at],
+                     %w[courses]
+
+    it 'returns correct expected data' do
+      actual_title = body_as_json[:data][:attributes][:first_name].downcase
+      expected_title = lecturer.first_name
+
+      expect(actual_title).to eq(expected_title)
+    end
+
+    context 'not valid request' do
+      let(:resource_endpoint) { "#{base_endpoint}/wat_lecturer?" }
+
+      it 'returns 404 response on not existed lecturer' do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    subject { post base_endpoint, params: request_params, headers: headers }
+
+    before(:each) { subject }
+
+    context 'group owner' do
+      it 'responds with a 201 status' do
+        expect(response).to have_http_status(:created)
+      end
+
+      include_examples 'json:api examples',
+                       %w[data],
+                       %w[id type attributes relationships],
+                       %w[first_name last_name patronymic created_at updated_at],
+                       %w[courses]
+
+      it 'returns created model' do
+        actual_title = body_as_json[:data][:attributes][:first_name]
+        expected_title = lecturer_params[:attributes][:first_name]
+
+        expect(actual_title).to eq(expected_title)
+      end
+
+      include_examples 'request errors examples'
+    end
+
+    context 'course binding' do
+      let_it_be(:course) { create(:course, group: student.group) }
+
+      let(:lecturer_params) do
+        course_params = {
+          relationships: {
+            courses: {
+              data: [{ id: course.id, type: 'course' }]
+            }
+          }
+        }
+
+        build(:lecturer_params).merge(course_params)
+      end
+
+      it 'return created model with bound course' do
+        actual_course_ids = relationship_data(:courses).map { |c| c[:id].to_i }
+
+        expect(actual_course_ids).to include(course.id)
+      end
+    end
+
+    context 'regular group member' do
+      let_it_be(:student) { create(:student, :group_member, user: user) }
+
+      it 'responds with 403 - forbidden' do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe 'PUT #update' do
+    subject { put resource_endpoint, params: request_params, headers: headers }
+
+    before(:each) { subject }
+
+    context 'group owner' do
+      it 'responds with a 200 status' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'updates a lecturer model' do
+        actual_title = lecturer.reload.first_name
+        expected_title = lecturer_params[:attributes][:first_name].downcase
+
+        expect(actual_title).to eq(expected_title)
+      end
+
+      include_examples 'json:api examples',
+                       %w[data],
+                       %w[id type attributes relationships],
+                       %w[first_name last_name patronymic created_at updated_at],
+                       %w[courses]
+
+      include_examples 'request errors examples'
+
+      context 'course binding' do
+        let_it_be(:course) { create(:course, group: student.group) }
+
+        let(:lecturer_params) do
+          course_params = {
+            relationships: {
+              courses: {
+                data: [{ id: course.id, type: 'course' }]
+              }
+            }
+          }
+
+          build(:lecturer_params).merge(course_params)
+        end
+
+        it 'return created model with bound course' do
+          actual_course_ids = relationship_data(:courses).map { |c| c[:id].to_i }
+
+          expect(actual_course_ids).to include(course.id)
+        end
+      end
+
+      context 'response with errors' do
+        let(:resource_endpoint) { "#{base_endpoint}/wat_lecturer?" }
+
+        it 'responds with a 404 status not existed lecturer' do
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
+    context 'regular group member' do
+      let_it_be(:student) { create(:student, :group_member, user: user) }
+
+      it 'responds with 403 - forbidden' do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    context 'group owner' do
+      it 'responds with a 204 status' do
+        delete resource_endpoint, headers: headers
+
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it 'responds with a 404 status not existed lecturer' do
+        delete "#{base_endpoint}/wat_lecturer?", headers: headers
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'deletes publisher' do
+        expect { delete resource_endpoint, headers: headers }.to change(Lecturer, :count).by(-1)
+      end
+    end
+
+    context 'regular group member' do
+      let_it_be(:student) { create(:student, :group_member, user: user) }
+
+      it 'responds with 403 - forbidden' do
+        delete resource_endpoint, headers: headers
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/spec/routing/api/v1/courses_routing_spec.rb
+++ b/spec/routing/api/v1/courses_routing_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+#
+# api_v1_courses  GET     /api/v1/courses(.:format)       api/v1/courses#index    {:format=>"json"}
+#                 POST    /api/v1/courses(.:format)       api/v1/courses#create   {:format=>"json"}
+#  api_v1_course  GET     /api/v1/courses/:id(.:format)   api/v1/courses#show     {:format=>"json"}
+#                 PATCH   /api/v1/courses/:id(.:format)   api/v1/courses#update   {:format=>"json"}
+#                 PUT     /api/v1/courses/:id(.:format)   api/v1/courses#update   {:format=>"json"}
+#                 DELETE  /api/v1/courses/:id(.:format)   api/v1/courses#destroy  {:format=>"json"}
+#
+describe Api::V1::CoursesController, 'routing' do
+  it 'routes to #index' do
+    expect(get('api/v1/courses')).to route_to('api/v1/courses#index', format: 'json')
+  end
+
+  it 'routes to #show' do
+    expect(get('api/v1/courses/1')).to route_to('api/v1/courses#show', id: '1', format: 'json')
+  end
+
+  it 'routes to #create' do
+    expect(post('api/v1/courses')).to route_to('api/v1/courses#create', format: 'json')
+  end
+
+  it 'routes to #update' do
+    expect(patch('api/v1/courses/1')).to route_to('api/v1/courses#update', id: '1', format: 'json')
+  end
+
+  it 'routes to #update' do
+    expect(put('api/v1/courses/1')).to route_to('api/v1/courses#update', id: '1', format: 'json')
+  end
+
+  it 'routes to #destroy' do
+    expect(delete('api/v1/courses/1')).to route_to('api/v1/courses#destroy', id: '1', format: 'json')
+  end
+end

--- a/spec/routing/api/v1/lecturers_routing_spec.rb
+++ b/spec/routing/api/v1/lecturers_routing_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+#
+# api_v1_lecturers  GET     /api/v1/lecturers(.:format)       api/v1/lecturers#index    {:format=>"json"}
+#                   POST    /api/v1/lecturers(.:format)       api/v1/lecturers#create   {:format=>"json"}
+#  api_v1_lecturer  GET     /api/v1/lecturers/:id(.:format)   api/v1/lecturers#show     {:format=>"json"}
+#                   PATCH   /api/v1/lecturers/:id(.:format)   api/v1/lecturers#update   {:format=>"json"}
+#                   PUT     /api/v1/lecturers/:id(.:format)   api/v1/lecturers#update   {:format=>"json"}
+#                   DELETE  /api/v1/lecturers/:id(.:format)   api/v1/lecturers#destroy  {:format=>"json"}
+#
+describe Api::V1::LecturersController, 'routing' do
+  it 'routes to #index' do
+    expect(get('api/v1/lecturers')).to route_to('api/v1/lecturers#index', format: 'json')
+  end
+
+  it 'routes to #show' do
+    expect(get('api/v1/lecturers/1')).to route_to('api/v1/lecturers#show', id: '1', format: 'json')
+  end
+
+  it 'routes to #create' do
+    expect(post('api/v1/lecturers')).to route_to('api/v1/lecturers#create', format: 'json')
+  end
+
+  it 'routes to #update' do
+    expect(patch('api/v1/lecturers/1')).to route_to('api/v1/lecturers#update', id: '1', format: 'json')
+  end
+
+  it 'routes to #update' do
+    expect(put('api/v1/lecturers/1')).to route_to('api/v1/lecturers#update', id: '1', format: 'json')
+  end
+
+  it 'routes to #destroy' do
+    expect(delete('api/v1/lecturers/1')).to route_to('api/v1/lecturers#destroy', id: '1', format: 'json')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -97,6 +97,14 @@ end
 
 Dir['./spec/support/custom_matchers/**/*.rb'].each { |f| require f }
 
+def relationship_data(rel_name)
+  json_data[:relationships][rel_name][:data]
+end
+
+def json_data
+  body_as_json[:data]
+end
+
 def body_as_json
   json_str_to_hash(response.body)
 end


### PR DESCRIPTION
Events can be bound to courses(optional).
Course-related events represent class schedules.

Courses and lecturers management(create, update) is allowed for group owner only.

`Api::V1::CoursesController` is used to managing courses(CRUD),
operations like create, update and delete is allowed to the group owner only.

`Api::V1::LecturersController` is used to managing lecturers(CRUD),
operations like create, update and delete is allowed to the group owner only.

Events could be bound to the course(optional) through
`Api::V1::EventsController`(create, update)