### PR TITLE
Closes #91 : Add authorization system

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,10 @@ gem 'puma', '~> 3.11'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+# Authorization framework for Ruby/Rails applications
+# https://github.com/palkan/action_policy
+gem 'action_policy'
+
 # Reduces boot times through caching; required in config/boot.rb
 # https://github.com/Shopify/bootsnap
 gem 'bootsnap', '>= 1.1.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     abstract_type (0.0.7)
+    action_policy (0.3.0)
     actioncable (5.2.2)
       actionpack (= 5.2.2)
       nio4r (~> 2.0)
@@ -311,6 +312,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  action_policy
   apitome
   bootsnap (>= 1.1.0)
   bullet

--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -19,9 +19,9 @@ module Api
     #     - delete particular course
     #
     class CoursesController < ApplicationController
-      set_default_serializer CourseSerializer
+      before_action :authorize!, only: %i[create update destroy]
 
-      before_action :authorize_edit!, only: %i[create update destroy]
+      set_default_serializer CourseSerializer
 
       # GET : api/v1/group/courses
       #
@@ -78,12 +78,6 @@ module Api
       end
 
       private
-
-      def authorize_edit!
-        return if current_student.group_owner?
-
-        raise Elplano::Errors::AuthError, I18n.t(:'errors.messages.access_denied')
-      end
 
       def filter_courses
         current_group&.courses || Course.none

--- a/app/controllers/api/v1/group/invites_controller.rb
+++ b/app/controllers/api/v1/group/invites_controller.rb
@@ -8,9 +8,9 @@ module Api
       #   Used to control group members invitations
       #
       class InvitesController < ApplicationController
-        set_default_serializer InviteSerializer
+        before_action :authorize!
 
-        before_action :authorize_student!
+        set_default_serializer InviteSerializer
 
         # GET : api/v1/group/invites
         #
@@ -44,12 +44,6 @@ module Api
         end
 
         private
-
-        def authorize_student!
-          return if current_student.group_owner?
-
-          raise Elplano::Errors::AuthError, I18n.t(:'errors.messages.access_denied')
-        end
 
         def filter_invites
           current_group.invites

--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -21,10 +21,9 @@ module Api
     #     - create a new group and become a group president.
     #
     class GroupsController < ApplicationController
-      set_default_serializer GroupSerializer
+      before_action :authorize!, only: %i[create update destroy]
 
-      before_action :authorize_edit, only: %i[update destroy]
-      before_action :authorize_create, only: :create
+      set_default_serializer GroupSerializer
 
       # GET : api/v1/group
       #

--- a/app/controllers/api/v1/lecturers_controller.rb
+++ b/app/controllers/api/v1/lecturers_controller.rb
@@ -19,9 +19,9 @@ module Api
     #     - delete particular lecturer
     #
     class LecturersController < ApplicationController
-      set_default_serializer LecturerSerializer
+      before_action :authorize!, only: %i[create update destroy]
 
-      before_action :authorize_edit!, only: %i[create update destroy]
+      set_default_serializer LecturerSerializer
 
       # GET : api/v1/group/lecturers
       #
@@ -81,12 +81,6 @@ module Api
 
       def filter_lecturers
         current_group&.lecturers || Lecturer.none
-      end
-
-      def authorize_edit!
-        return if current_student.group_owner?
-
-        raise Elplano::Errors::AuthError, I18n.t(:'errors.messages.access_denied')
       end
 
       def lecturer_params

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,8 @@
 #   Used as base controller
 #
 class ApplicationController < ActionController::API
+  include ActionPolicy::Controller
+
   include RestifyParams
 
   include Handlers::Exception
@@ -18,6 +20,8 @@ class ApplicationController < ActionController::API
   before_action :set_default_headers
 
   prepend_before_action :doorkeeper_authorize!
+
+  authorize :user, through: :current_student
 
   def check_request_format
     head :unsupported_media_type unless json_request?

--- a/app/controllers/concerns/handlers/exception.rb
+++ b/app/controllers/concerns/handlers/exception.rb
@@ -43,9 +43,9 @@ module Handlers
 
       # Return 403 - Forbidden (No access rights)
       #
-      rescue_from Elplano::Errors::AuthError do |e|
+      rescue_from ActionPolicy::Unauthorized do |e|
         handle_error(e, :forbidden) do
-          [{ status: 403, detail: e.message, source: { pointer: 'authorization scope' } }]
+          [{ status: 403, detail: e.result.message, source: { pointer: 'authorization scope' } }]
         end
       end
     end

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# CoursePolicy
+#
+#   Authorization policy for course management
+#
+class CoursePolicy < ActionPolicy::Base
+  %i[create? update? destroy?].each do |method|
+    define_method(method) { user.group_owner? }
+  end
+end

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# GroupPolicy
+#
+#   Authorization policy for groups management
+#
+class GroupPolicy < ActionPolicy::Base
+  %i[update? destroy?].each do |method|
+    define_method(method) { user.group_owner? }
+  end
+
+  def create?
+    !user.any_group?
+  end
+end

--- a/app/policies/invite_policy.rb
+++ b/app/policies/invite_policy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# InvitePolicy
+#
+#   Authorization policy for group invite management
+#
+class InvitePolicy < ActionPolicy::Base
+  %i[index? show? create?].each do |method|
+    define_method(method) { user.group_owner? }
+  end
+end

--- a/app/policies/lecturer_policy.rb
+++ b/app/policies/lecturer_policy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# LecturerPolicy
+#
+#   Authorization policy for lecturers management
+#
+class LecturerPolicy < ActionPolicy::Base
+  %i[create? update? destroy?].each do |method|
+    define_method(method) { user.group_owner? }
+  end
+end

--- a/spec/policies/course_policy_spec.rb
+++ b/spec/policies/course_policy_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CoursePolicy do
+  let(:course) { build_stubbed(:course) }
+  let(:policy) { described_class.new(course, user: user) }
+
+  context 'when student is a group owner' do
+    let_it_be(:user) { create(:student, :group_supervisor) }
+
+    describe '#create?' do
+      subject { policy.apply(:create?) }
+
+      it { is_expected.to eq(true) }
+    end
+
+    describe '#update?' do
+      subject { policy.apply(:update?) }
+
+      it { is_expected.to eq(true) }
+    end
+
+    describe '#destroy?' do
+      subject { policy.apply(:destroy?) }
+
+      it { is_expected.to eq(true) }
+    end
+  end
+
+  context 'when user is a regular group member' do
+    let_it_be(:user) { create(:student, :group_member) }
+
+    describe '#create?' do
+      subject { policy.apply(:create?) }
+
+      it { is_expected.to eq(false) }
+    end
+
+    describe '#update?' do
+      subject { policy.apply(:update?) }
+
+      it { is_expected.to eq(false) }
+    end
+
+    describe '#destroy?' do
+      subject { policy.apply(:destroy?) }
+
+      it { is_expected.to eq(false) }
+    end
+  end
+end

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GroupPolicy do
+  let(:group)   { build_stubbed(:group) }
+  let(:policy)  { described_class.new(group, user: user) }
+
+  context 'when a student has no group' do
+    let_it_be(:user) { create(:student) }
+
+    describe '#create?' do
+      subject { policy.apply(:create?) }
+
+      it { is_expected.to eq(true) }
+    end
+  end
+
+  context 'when student is a group owner' do
+    let_it_be(:user) { create(:student, :group_supervisor) }
+
+    describe '#create?' do
+      subject { policy.apply(:create?) }
+
+      it { is_expected.to eq(false) }
+    end
+
+    describe '#update?' do
+      subject { policy.apply(:update?) }
+
+      it { is_expected.to eq(true) }
+    end
+
+    describe '#destroy?' do
+      subject { policy.apply(:destroy?) }
+
+      it { is_expected.to eq(true) }
+    end
+  end
+
+  context 'when user is a regular group member' do
+    let_it_be(:user) { create(:student, :group_member) }
+
+    describe '#create?' do
+      subject { policy.apply(:create?) }
+
+      it { is_expected.to eq(false) }
+    end
+
+    describe '#update?' do
+      subject { policy.apply(:update?) }
+
+      it { is_expected.to eq(false) }
+    end
+
+    describe '#destroy?' do
+      subject { policy.apply(:destroy?) }
+
+      it { is_expected.to eq(false) }
+    end
+  end
+end

--- a/spec/policies/invite_policy_spec.rb
+++ b/spec/policies/invite_policy_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe InvitePolicy do
+  let(:invite) { build_stubbed(:invite) }
+  let(:policy) { described_class.new(invite, user: user) }
+
+  context 'when student is a group owner' do
+    let_it_be(:user) { create(:student, :group_supervisor) }
+
+    describe '#create?' do
+      subject { policy.apply(:index?) }
+
+      it { is_expected.to eq(true) }
+    end
+
+    describe '#update?' do
+      subject { policy.apply(:show?) }
+
+      it { is_expected.to eq(true) }
+    end
+
+    describe '#destroy?' do
+      subject { policy.apply(:create?) }
+
+      it { is_expected.to eq(true) }
+    end
+  end
+
+  context 'when user is a regular group member' do
+    let_it_be(:user) { create(:student, :group_member) }
+
+    describe '#create?' do
+      subject { policy.apply(:index?) }
+
+      it { is_expected.to eq(false) }
+    end
+
+    describe '#update?' do
+      subject { policy.apply(:show?) }
+
+      it { is_expected.to eq(false) }
+    end
+
+    describe '#destroy?' do
+      subject { policy.apply(:create?) }
+
+      it { is_expected.to eq(false) }
+    end
+  end
+end

--- a/spec/policies/lecturer_policy_spec.rb
+++ b/spec/policies/lecturer_policy_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LecturerPolicy do
+  let(:lecturer)  { build_stubbed(:lecturer) }
+  let(:policy)    { described_class.new(lecturer, user: user) }
+
+  context 'when student is a group owner' do
+    let_it_be(:user) { create(:student, :group_supervisor) }
+
+    describe '#create?' do
+      subject { policy.apply(:create?) }
+
+      it { is_expected.to eq(true) }
+    end
+
+    describe '#update?' do
+      subject { policy.apply(:update?) }
+
+      it { is_expected.to eq(true) }
+    end
+
+    describe '#destroy?' do
+      subject { policy.apply(:destroy?) }
+
+      it { is_expected.to eq(true) }
+    end
+  end
+
+  context 'when user is a regular group member' do
+    let_it_be(:user) { create(:student, :group_member) }
+
+    describe '#create?' do
+      subject { policy.apply(:create?) }
+
+      it { is_expected.to eq(false) }
+    end
+
+    describe '#update?' do
+      subject { policy.apply(:update?) }
+
+      it { is_expected.to eq(false) }
+    end
+
+    describe '#destroy?' do
+      subject { policy.apply(:destroy?) }
+
+      it { is_expected.to eq(false) }
+    end
+  end
+end


### PR DESCRIPTION
Action Policy gem is used to perform all authorization scenarios in application

 - All policies located in the `app/policies`;
 - Policies naming should be with using the corresponding singular resource name (model name) with a Policy suffix,
   e.g. Course -> CoursePolicy;
 - Policies rules naming should be with using a predicate form of the corresponding activity (typically, a controller's action),
   e.g. `CourseController#update` -> `CoursePolicy#update?`.

Rules must be public methods on the class. Using private methods as rules will raise an error.

A Policy is instantiated with the target `record` (authorization object) and the authorization context (by default equals to `user`)

When authorization is successful (i.e., the corresponding rule returns `true`), nothing happens,
but in case of an authorization failure `ActionPolicy::Unauthorized` error is raised