### PR TITLE
Fix security alerts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,7 +154,7 @@ GEM
     multi_json (1.13.1)
     mustache (1.1.0)
     nio4r (2.3.1)
-    nokogiri (1.10.1)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
     parser (2.5.3.0)


### PR DESCRIPTION
nokogiri vulnerability:

A command injection vulnerability in Nokogiri v1.10.3 and earlier allows commands to be executed in a subprocess via Ruby's Kernel.open method.
Processes are vulnerable only if the undocumented method `Nokogiri::CSS::Tokenizer#load_file` is being called with unsafe user input as the filename.
This vulnerability appears in code generated by the Rexical gem versions v1.0.6 and earlier.
Rexical is used by Nokogiri to generate lexical scanner code for parsing CSS queries.
The underlying vulnerability was addressed in Rexical v1.0.7 and Nokogiri upgraded to this version of Rexical in Nokogiri v1.10.4.