### PR TITLE
Closes #95 Add events filtration

### DIFF
--- a/app/finders/events_finder.rb
+++ b/app/finders/events_finder.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# EventsFinder
+#
+#   Used to search, filter, and sort the collection of student's events
+#
+# Arguments:
+#
+#   params: optional search, filter and sort parameters
+#
+# NOTE :
+#
+#   - by default returns events sorted by recently added.
+#   - by default returns all appointed events(personal + group events).
+#
+class EventsFinder
+  attr_reader :params, :student
+
+  # @param student [Student] -
+  #
+  # @param params [Hash] - (optional, default: {}) filter and sort parameters
+  #
+  # @option params [String, Symbol] :scope -
+  #   One of the events scope(appointed, authored)
+  #
+  # @option params [String, Symbol] :type -
+  #   One of the eventable types(group, personal).
+  #
+  def initialize(student, params = {})
+    @student = student
+    @params = params
+  end
+
+  # Perform filtration and sort on student's events list
+  #
+  # @note by default returns all appointed events(personal + group)
+  #   sorted by recently created
+  #
+  def execute
+    collection = perform_filtration
+
+    sort(collection)
+  end
+
+  private
+
+  def perform_filtration
+    filters = {
+      'appointed' => filter_appointed,
+      'authored' => filter_authored
+    }
+
+    filters.fetch(params[:scope]) { filter_appointed }
+  end
+
+  def filter_authored
+    student.created_events.filter(params[:type])
+  end
+
+  def filter_appointed
+    filters = {
+      'group' => Event.filter('group')
+                      .where(eventable_id: student.group_id),
+      'personal' => Event.filter('personal')
+                         .where(eventable_id: student.id)
+    }
+
+    filters.fetch(params[:type]) { filters.values.inject(&:or) }
+  end
+
+  def sort(items)
+    params[:sort].blank? ? items.reorder(id: :desc) : items.order_by(params[:sort])
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -86,6 +86,11 @@ class Event < ApplicationRecord
 
   belongs_to :eventable, polymorphic: true
 
+  scope :personal, -> { where(eventable_type: 'Student') }
+  scope :groups,   -> { where(eventable_type: 'Group') }
+
+  scope :personal_or_group, -> { groups.or(personal) }
+
   validates :creator, :timezone, presence: true
   validates :title, presence: true, length: { in: 3..250 }
 
@@ -98,4 +103,17 @@ class Event < ApplicationRecord
             timeliness: { on_or_after: :start_at }
 
   validates :timezone, timezone_existence: true
+
+  def self.filter(filter_name)
+    case filter_name.to_s
+    when 'group'
+      groups
+    when 'personal'
+      personal
+    when ''
+      personal_or_group
+    else
+      none
+    end
+  end
 end

--- a/spec/acceptance/api/v1/events_spec.rb
+++ b/spec/acceptance/api/v1/events_spec.rb
@@ -43,6 +43,21 @@ resource "User's events" do
       explanation <<~DESC
         Returns a list of the available events.
 
+        <b>NOTE<b>:
+
+        - by default, this endpoint returns all appointed events(personal + group)
+        - be default, this endpoint returns sorts events by recently created
+
+        <b>Optional query params:</b>
+
+          - `?scope=authored` - Filter by event scope:
+            - `authored` - created by current authenticated student
+            - `appointed` - created for current authenticated student
+
+          - `?type=personal` - Filter by event type(eventable type):
+            - `group` - created for everyone in current student's group
+            - `personal` - create only for current user(self event and personal events from group owner)
+
         See model attributes description in the section description.
       DESC
 
@@ -142,7 +157,8 @@ resource "User's events" do
 
         <b>NOTE</b> : 
 
-          - `start_at` should be after or on current date and time and before `end_at` and `end_at` should be after `start_at`
+          - update allowed only for events created by current authenticated student.
+          - `start_at` should be after or on current date and time and before `end_at` and `end_at` should be after `start_at`.
 
         See model attributes description in the section description.
       DESC
@@ -160,6 +176,10 @@ resource "User's events" do
     example 'DELETE : Deletes selected event' do
       explanation <<~DESC
         Deletes an event.
+
+        <b>NOTE</b> :
+
+          - delete allowed only for events created by current authenticated student.
       DESC
 
       do_request

--- a/spec/finders/events_finder_spec.rb
+++ b/spec/finders/events_finder_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EventsFinder do
+  let_it_be(:member) { create(:student) }
+  let_it_be(:president) { create(:student, :president) }
+
+  let_it_be(:group) do
+    create(:group, president: president, students: [president, member])
+  end
+
+  let_it_be(:personal_event) do
+    create(:event, creator: president, eventable: member)
+  end
+
+  let_it_be(:group_event) do
+    create(:event, creator: president, eventable: president.group)
+  end
+
+  describe '#execute' do
+    subject { described_class.new(student, params).execute }
+
+    context 'when student is a group president' do
+      let_it_be(:student) { president }
+
+      context 'when params are default(empty)' do
+        let_it_be(:params) { {} }
+
+        it { is_expected.to eq([group_event]) }
+      end
+
+      context 'when scope param is authored' do
+        let_it_be(:params) { { scope: 'authored' } }
+
+        it { is_expected.to eq([group_event, personal_event]) }
+      end
+
+      context 'when scope param is appointed' do
+        let_it_be(:params) { { scope: 'appointed' } }
+
+        it { is_expected.to eq([group_event]) }
+      end
+
+      context 'when type params is group' do
+        let_it_be(:params) { { type: 'group' } }
+
+        it { is_expected.to eq([group_event]) }
+      end
+
+      context 'when type params is personal' do
+        let_it_be(:params) { { type: 'personal' } }
+
+        it { is_expected.to eq([]) }
+      end
+
+      context 'when type params is personal and scope is appointed' do
+        let_it_be(:params) { { type: 'personal', scope: 'appointed' } }
+
+        it { is_expected.to eq([]) }
+      end
+
+      context 'when type params is group and scope is appointed' do
+        let_it_be(:params) { { type: 'group', scope: 'appointed' } }
+
+        it { is_expected.to eq([group_event]) }
+      end
+
+      context 'when type params is personal and scope is authored' do
+        let_it_be(:params) { { type: 'personal', scope: 'authored' } }
+
+        it { is_expected.to eq([personal_event]) }
+      end
+
+      context 'when type params is group and scope is authored' do
+        let_it_be(:params) { { type: 'group', scope: 'authored' } }
+
+        it { is_expected.to eq([group_event]) }
+      end
+    end
+
+    context 'when student is a regular member' do
+      let_it_be(:student) { member }
+
+      context 'when params are default(empty)' do
+        let_it_be(:params) { {} }
+
+        it { is_expected.to eq([group_event, personal_event]) }
+      end
+
+      context 'when scope param is authored' do
+        let_it_be(:params) { { scope: 'authored' } }
+
+        it { is_expected.to eq([]) }
+      end
+
+      context 'when scope param is appointed' do
+        let_it_be(:params) { { scope: 'appointed' } }
+
+        it { is_expected.to eq([group_event, personal_event]) }
+      end
+
+      context 'when type params is group' do
+        let_it_be(:params) { { type: 'group' } }
+
+        it { is_expected.to eq([group_event]) }
+      end
+
+      context 'when type params is personal' do
+        let_it_be(:params) { { type: 'personal' } }
+
+        it { is_expected.to eq([personal_event]) }
+      end
+
+      context 'when type params is personal and scope is appointed' do
+        let_it_be(:params) { { type: 'personal', scope: 'appointed' } }
+
+        it { is_expected.to eq([personal_event]) }
+      end
+
+      context 'when type params is group and scope is appointed' do
+        let_it_be(:params) { { type: 'group', scope: 'appointed' } }
+
+        it { is_expected.to eq([group_event]) }
+      end
+
+      context 'when type params is personal and scope is authored' do
+        let_it_be(:params) { { type: 'personal', scope: 'authored' } }
+
+        it { is_expected.to eq([]) }
+      end
+
+      context 'when type params is group and scope is authored' do
+        let_it_be(:params) { { type: 'group', scope: 'authored' } }
+
+        it { is_expected.to eq([]) }
+      end
+    end
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -30,4 +30,62 @@ RSpec.describe Event, type: :model do
                .backed_by_column_of_type(:string)
     end
   end
+
+  context 'scopes' do
+    context 'eventable type' do
+      let_it_be(:student) { create(:student, :group_supervisor) }
+
+      let_it_be(:personal_event) do
+        create(:event, creator: student, eventable: student)
+      end
+
+      let_it_be(:group_event) do
+        create(:event, creator: student, eventable: student.group)
+      end
+
+      describe '.personal' do
+        subject { described_class.personal }
+
+        it { is_expected.to eq([personal_event]) }
+      end
+
+      describe '.groups' do
+        subject { described_class.groups }
+
+        it { is_expected.to eq([group_event]) }
+      end
+
+      describe '.personal_or_group' do
+        subject { described_class.personal_or_group }
+
+        it { is_expected.to match_array([personal_event, group_event]) }
+      end
+    end
+  end
+
+  describe '.filter' do
+    let_it_be(:event) { double }
+
+    it 'returns none with not existed filter name' do
+      expect(described_class.filter('wat')).to eq([])
+    end
+
+    it 'filters by default group and personal events' do
+      expect(described_class).to receive(:personal_or_group).and_return([event])
+
+      expect(described_class.filter(nil)).to eq([event])
+    end
+
+    it 'filters by group events' do
+      expect(described_class).to receive(:groups).and_return([event])
+
+      expect(described_class.filter('group')).to eq([event])
+    end
+
+    it 'filters by personal events' do
+      expect(described_class).to receive(:personal).and_return([event])
+
+      expect(described_class.filter('personal')).to eq([event])
+    end
+  end
 end

--- a/spec/requests/api/v1/events_spec.rb
+++ b/spec/requests/api/v1/events_spec.rb
@@ -22,8 +22,12 @@ RSpec.describe Api::V1::EventsController, type: :request do
   describe 'GET #index' do
     subject { get base_endpoint, headers: headers }
 
+    let_it_be(:president) do
+      create(:student, :group_supervisor, group: student.group)
+    end
+
     let_it_be(:events) do
-      create_list(:event, 2, creator: student, eventable: student)
+      create_list(:event, 2, creator: president, eventable: student)
     end
 
     context 'N+1' do
@@ -36,6 +40,26 @@ RSpec.describe Api::V1::EventsController, type: :request do
       it { expect(response).to have_http_status(:ok) }
 
       it { expect(json_data.count).to be(3) }
+    end
+
+    context 'when type filter param is provided' do
+      subject { get "#{base_endpoint}?type=group", headers: headers }
+
+      before(:each) { subject }
+
+      it { expect(response).to have_http_status(:ok) }
+
+      it { expect(json_data.count).to be(0) }
+    end
+
+    context 'when scope filter param is provided' do
+      subject { get "#{base_endpoint}?scope=authored", headers: headers }
+
+      before(:each) { subject }
+
+      it { expect(response).to have_http_status(:ok) }
+
+      it { expect(json_data.count).to be(1) }
     end
   end
 


### PR DESCRIPTION
Added filtration for student's event

- filter by scope(authored or appointed events)
- filter by event type(eventable type, group or personal)

`EventsFinder` is used to perform filtration and sorting on student's events list