### PR TITLE
Add color to events

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -120,6 +120,7 @@ module Api
           .permit(
             :title, :description, :status,
             :start_at, :end_at, :timezone,
+            :background_color, :foreground_color,
             :course_id, :eventable_id, :eventable_type,
             recurrence: []
           )

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -104,6 +104,8 @@ class Event < ApplicationRecord
 
   validates :timezone, timezone_existence: true
 
+  validates :foreground_color, :background_color, allow_nil: true, color: true
+
   def self.filter(filter_name)
     case filter_name.to_s
     when 'group'

--- a/app/services/events/create.rb
+++ b/app/services/events/create.rb
@@ -48,6 +48,13 @@ module Events
     # @option params [String] :eventable_type -
     #   The entity identity to which the event is attached
     #
+    # @option params [String] :background_color -
+    #   The background color presented by HEX
+    #
+    # @option params [String] :foreground_color -
+    #   The foreground color that can be used to write on top of
+    #   a background with 'background' color presented by HEX
+    #
     # @option params [Array<String>] :recurrence -
     #   Recurrence rules if an event is recurrent
     #

--- a/app/validators/color_validator.rb
+++ b/app/validators/color_validator.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# ColorValidator
+#
+#   Used to check if the value of an attribute is a valid hex color.
+#
+# @example Validate that the event color is a valid hex color.
+#   class Event < ActiveRecord::Base
+#     attr_accessor :color_attribute
+#
+#     validates :color_attribute, color: true
+#   end
+#
+class ColorValidator < ActiveModel::EachValidator
+  HEX_COLOR_FORMAT = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/.freeze
+
+  def validate_each(record, attribute, value)
+    return if allow_nil?(options) && value.nil?
+
+    add_error(record, attribute) unless valid_format?(value)
+  end
+
+  private
+
+  def allow_nil?(options)
+    options.fetch(:allow_nil, false)
+  end
+
+  def valid_format?(color)
+    (color =~ HEX_COLOR_FORMAT).present?
+  end
+
+  def add_error(record, attribute)
+    record.errors.add(attribute, I18n.t('errors.messages.color.invalid_format'))
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,8 @@ en:
         invalid_markup: 'contains invalid HTML markup: %{error}'
       timezone:
         not_exist: 'does not exist'
+      color:
+        invalid_format: 'is not a valid hexadecimal color'
       invalid_date: "is not a valid date"
       invalid_time: "is not a valid time"
       invalid_datetime: "is not a valid datetime"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -40,6 +40,8 @@ es:
         description: 'descripción'
         timezone: 'zona horaria'
         recurrence: 'recurrencia'
+        foreground_color: 'color de primer plano'
+        background_color: 'color de fondo'
       course:
         title: 'titulo'
       group:
@@ -171,6 +173,8 @@ es:
         invalid_markup: 'contiene código HTML no válido: %{error}'
       timezone:
         not_exist: 'no existe'
+      color:
+        invalid_format: 'no es un color hexadecimal válido'
       invalid_date: 'no es una fecha válida'
       invalid_time: 'no es un tiempo valido'
       invalid_datetime: 'no es una fecha y hora válida'

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -40,6 +40,8 @@ ru:
         description: 'описание'
         timezone: 'часовой пояс'
         recurrence: 'настройки рекуррентности'
+        foreground_color: 'цвет переднего плана'
+        background_color: 'фоновый цвет'
       course:
         title: 'заголовок'
       group:
@@ -195,6 +197,8 @@ ru:
         invalid_markup: 'невалидная разметка HTML: %{error}'
       timezone:
         not_exist: 'не существует'
+      color:
+        invalid_format: 'не является допустимым шестнадцатеричным цветом'
       invalid_date: 'невалидная дата'
       invalid_time: 'не является валидным временем'
       invalid_datetime: 'не является валидной датой и временем'

--- a/db/migrate/20190828141408_add_colors_to_event.rb
+++ b/db/migrate/20190828141408_add_colors_to_event.rb
@@ -1,0 +1,6 @@
+class AddColorsToEvent < ActiveRecord::Migration[5.2]
+  def change
+    add_column  :events,:foreground_color, :string, limit: 7
+    add_column  :events,:background_color, :string, limit: 7
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_23_134243) do
+ActiveRecord::Schema.define(version: 2019_08_28_141408) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,6 +40,8 @@ ActiveRecord::Schema.define(version: 2019_08_23_134243) do
     t.bigint "course_id"
     t.string "eventable_type", null: false
     t.bigint "eventable_id", null: false
+    t.string "foreground_color", limit: 7
+    t.string "background_color", limit: 7
     t.index ["course_id"], name: "index_events_on_course_id"
     t.index ["creator_id"], name: "index_events_on_creator_id"
     t.index ["eventable_id", "eventable_type"], name: "index_events_on_eventable_id_and_eventable_type"

--- a/spec/acceptance/api/v1/events_spec.rb
+++ b/spec/acceptance/api/v1/events_spec.rb
@@ -19,6 +19,8 @@ resource "User's events" do
      - `timezone` - Timezone settings.
      - `start_at` - Represents when event starts.
      - `end_at` - Represents when event ends.
+     - `background_color` - Represents the background color.
+     - `foreground_color` - Represents the foreground color that can be used to write on top of a background with 'background' color.
      - `timestamps`
   
      Also, includes references to the event creator, attached course, and for whom the event was created.
@@ -99,6 +101,8 @@ resource "User's events" do
       parameter :course_id, 'The course identity to which the event is attached'
       parameter :eventable_type, 'The entity type to which the event is attached(Student, Group)', required: true
       parameter :eventable_id, 'The entity identity to which the event is attached', required: true
+      parameter :background_color, 'The background color (HEX)'
+      parameter :foreground_color, "The foreground color that can be used to write on top of a background with 'background' color (HEX)"
     end
 
     let(:raw_post) do
@@ -143,6 +147,8 @@ resource "User's events" do
       parameter :course_id, 'The course identity to which the event is attached'
       parameter :eventable_type, 'The entity type to which the event is attached(Student, Group)', required: true
       parameter :eventable_id, 'The entity identity to which the event is attached', required: true
+      parameter :background_color, 'The background color (HEX)'
+      parameter :foreground_color, "The foreground color that can be used to write on top of a background with 'background' color (HEX)"
     end
 
     let(:raw_post) do

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -14,6 +14,9 @@ FactoryBot.define do
       ]
     }
 
+    background_color { Faker::Color.hex_color }
+    foreground_color { Faker::Color.hex_color }
+
     creator
   end
 
@@ -32,7 +35,9 @@ FactoryBot.define do
           'RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3'
         ],
         eventable_id: create(:student).id,
-        eventable_type: 'Student'
+        eventable_type: 'Student',
+        background_color: Faker::Color.hex_color,
+        foreground_color: Faker::Color.hex_color
       }
     end
   end
@@ -47,6 +52,8 @@ FactoryBot.define do
         end_at: nil,
         timezone: nil,
         recurrence: [],
+        background_color: 'wat',
+        foreground_color: 'so'
       }
     end
   end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -29,6 +29,86 @@ RSpec.describe Event, type: :model do
                .with_values(confirmed: 'confirmed', tentative: 'tentative', cancelled: 'cancelled')
                .backed_by_column_of_type(:string)
     end
+
+    it { should allow_value('#1f1f1F').for(:background_color) }
+
+    it { should allow_value('#AFAFAF').for(:background_color) }
+
+    it { should allow_value('#222fff').for(:background_color) }
+
+    it { should allow_value('#F00').for(:background_color) }
+
+    it { should allow_value('#1AFFa1').for(:background_color) }
+
+    it { should allow_value('#000000').for(:background_color) }
+
+    it { should allow_value('#ea00FF').for(:background_color) }
+
+    it { should allow_value('#eb0').for(:background_color) }
+
+    it { should allow_value(nil).for(:background_color) }
+
+    it { should_not allow_value('123456').for(:background_color) }
+
+    it { should_not allow_value('#afafah').for(:background_color) }
+
+    it { should_not allow_value('#123abce').for(:background_color) }
+
+    it { should_not allow_value('aFaE3f').for(:background_color) }
+
+    it { should_not allow_value('F00').for(:background_color) }
+
+    it { should_not allow_value('#afaf').for(:background_color) }
+
+    it { should_not allow_value('#afaf').for(:background_color) }
+
+    it { should_not allow_value('#F0h').for(:background_color) }
+
+    it { should_not allow_value('').for(:background_color) }
+
+    it { should_not allow_value(0).for(:background_color) }
+
+    it { should_not allow_value('#1f1f1F1f1f1F').for(:background_color) }
+
+    it { should allow_value('#1f1f1F').for(:foreground_color) }
+
+    it { should allow_value('#AFAFAF').for(:foreground_color) }
+
+    it { should allow_value('#222fff').for(:foreground_color) }
+
+    it { should allow_value('#F00').for(:foreground_color) }
+
+    it { should allow_value('#1AFFa1').for(:foreground_color) }
+
+    it { should allow_value('#000000').for(:foreground_color) }
+
+    it { should allow_value('#ea00FF').for(:foreground_color) }
+
+    it { should allow_value('#eb0').for(:foreground_color) }
+
+    it { should allow_value(nil).for(:foreground_color) }
+
+    it { should_not allow_value('123456').for(:foreground_color) }
+
+    it { should_not allow_value('#afafah').for(:foreground_color) }
+
+    it { should_not allow_value('#123abce').for(:foreground_color) }
+
+    it { should_not allow_value('aFaE3f').for(:foreground_color) }
+
+    it { should_not allow_value('F00').for(:foreground_color) }
+
+    it { should_not allow_value('#afaf').for(:foreground_color) }
+
+    it { should_not allow_value('#afaf').for(:foreground_color) }
+
+    it { should_not allow_value('#F0h').for(:foreground_color) }
+
+    it { should_not allow_value('').for(:foreground_color) }
+
+    it { should_not allow_value(0).for(:foreground_color) }
+
+    it { should_not allow_value('#1f1f1F1f1f1F').for(:foreground_color) }
   end
 
   context 'scopes' do

--- a/spec/validators/color_validator_spec.rb
+++ b/spec/validators/color_validator_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ColorValidator, type: :model do
+  subject { dummy.new }
+
+  context 'when allow nil option not set' do
+    let_it_be(:dummy) do
+      Class.new do
+        include ActiveModel::Validations
+
+        attr_accessor :color
+
+        validates :color, color: true
+      end
+    end
+
+    it { is_expected.to allow_value('#1f1f1F').for(:color) }
+
+    it { is_expected.to allow_value('#AFAFAF').for(:color) }
+
+    it { is_expected.to allow_value('#222fff').for(:color) }
+
+    it { is_expected.to allow_value('#F00').for(:color) }
+
+    it { is_expected.to allow_value('#1AFFa1').for(:color) }
+
+    it { is_expected.to allow_value('#000000').for(:color) }
+
+    it { is_expected.to allow_value('#ea00FF').for(:color) }
+
+    it { is_expected.to allow_value('#eb0').for(:color) }
+
+    it { is_expected.not_to allow_value('123456').for(:color) }
+
+    it { is_expected.not_to allow_value('#afafah').for(:color) }
+
+    it { is_expected.not_to allow_value('#123abce').for(:color) }
+
+    it { is_expected.not_to allow_value('aFaE3f').for(:color) }
+
+    it { is_expected.not_to allow_value('F00').for(:color) }
+
+    it { is_expected.not_to allow_value('#afaf').for(:color) }
+
+    it { is_expected.not_to allow_value('#afaf').for(:color) }
+
+    it { is_expected.not_to allow_value('#F0h').for(:color) }
+
+    it { is_expected.not_to allow_value('').for(:color) }
+
+    it { is_expected.not_to allow_value(0).for(:color) }
+
+    it { is_expected.not_to allow_value('#1f1f1F1f1f1F').for(:color) }
+  end
+
+  context 'when allow nil is set to true' do
+    let_it_be(:dummy) do
+      Class.new do
+        include ActiveModel::Validations
+
+        attr_accessor :color
+
+        validates :color, color: true, allow_nil: true
+      end
+    end
+
+    it { is_expected.to allow_value(nil).for(:color) }
+  end
+
+  context 'when allow nil is set to false' do
+    let_it_be(:dummy) do
+      Class.new do
+        include ActiveModel::Validations
+
+        attr_accessor :color
+
+        validates :color, color: true, allow_nil: false
+      end
+    end
+
+    it { is_expected.not_to allow_value(nil).for(:color) }
+  end
+end


### PR DESCRIPTION
Added customizable foreground and background color options for the events.
The color option should be presented by HEX value.

`ColorValidator` is used to validate color value against HEX format.