### PR TITLE
Closes #103 Add endpoint titles

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -7,6 +7,8 @@
 class AboutController < ApplicationController
   skip_before_action :authorize_access!
 
+  denote_title_header 'About'
+
   # GET : /
   #
   # Show app information

--- a/app/controllers/api/v1/admin/application_controller.rb
+++ b/app/controllers/api/v1/admin/application_controller.rb
@@ -10,6 +10,8 @@ module Api
       #
       class ApplicationController < ::ApplicationController
         authorize_with! ::Admin::UserPolicy
+
+        denote_title_header 'Admin'
       end
     end
   end

--- a/app/controllers/api/v1/admin/settings_controller.rb
+++ b/app/controllers/api/v1/admin/settings_controller.rb
@@ -9,6 +9,7 @@ module Api
       #     (admin configurable application settings)
       #
       class SettingsController < Admin::ApplicationController
+        denote_title_header 'Settings'
 
         # PATCH/PUT : api/v1/admin/settings
         #

--- a/app/controllers/api/v1/admin/system/health_controller.rb
+++ b/app/controllers/api/v1/admin/system/health_controller.rb
@@ -9,6 +9,8 @@ module Api
         #   Used to administrate system health status
         #
         class HealthController < Admin::ApplicationController
+          denote_title_header 'System', 'Health'
+
           # GET : api/v1/admin/system/health?type=
           #
           #   query parameters :

--- a/app/controllers/api/v1/admin/system/information_controller.rb
+++ b/app/controllers/api/v1/admin/system/information_controller.rb
@@ -10,7 +10,9 @@ module Api
         #     (get information about CPU, RAM and DISK)
         #
         class InformationController < Admin::ApplicationController
-          # GET : api/v1/admin/systems
+          denote_title_header 'System', 'Information'
+
+          # GET : api/v1/admin/system/information
           #
           # Get usage information about CPU, RAM, and DISK
           #

--- a/app/controllers/api/v1/admin/users_controller.rb
+++ b/app/controllers/api/v1/admin/users_controller.rb
@@ -10,6 +10,8 @@ module Api
       class UsersController < Admin::ApplicationController
         set_default_serializer UserSerializer
 
+        denote_title_header 'Users'
+
         # GET : api/v1/admin/users
         #
         #   optional query parameters :

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -23,6 +23,8 @@ module Api
     class EventsController < ApplicationController
       set_default_serializer EventSerializer
 
+      denote_title_header 'Events'
+
       # GET : api/v1/events
       #
       #   optional query parameters :

--- a/app/controllers/api/v1/group/courses_controller.rb
+++ b/app/controllers/api/v1/group/courses_controller.rb
@@ -24,6 +24,8 @@ module Api
 
         set_default_serializer CourseSerializer
 
+        denote_title_header 'Group', 'Courses'
+
         # GET : api/v1/group/courses
         #
         # Get list of courses

--- a/app/controllers/api/v1/group/invites_controller.rb
+++ b/app/controllers/api/v1/group/invites_controller.rb
@@ -12,6 +12,8 @@ module Api
 
         set_default_serializer InviteSerializer
 
+        denote_title_header 'Group', 'Invites'
+
         # GET : api/v1/group/invites
         #
         # Get list of group invites

--- a/app/controllers/api/v1/group/lecturers_controller.rb
+++ b/app/controllers/api/v1/group/lecturers_controller.rb
@@ -24,6 +24,8 @@ module Api
 
         set_default_serializer LecturerSerializer
 
+        denote_title_header 'Group', 'Lecturers'
+
         rescue_from Errno::ENOENT, KeyError do |e|
           handle_error(e, :bad_request) do
             [{ status: 400, detail: e.message, source: { pointer: '/data/attributes/avatar' } }]

--- a/app/controllers/api/v1/group/students_controller.rb
+++ b/app/controllers/api/v1/group/students_controller.rb
@@ -13,6 +13,8 @@ module Api
       class StudentsController < ApplicationController
         set_default_serializer StudentSerializer
 
+        denote_title_header 'Group', 'Students'
+
         # GET : api/v1/group/students
         #
         # Get list of group members

--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -25,6 +25,8 @@ module Api
 
       set_default_serializer GroupSerializer
 
+      denote_title_header 'Group'
+
       # GET : api/v1/group
       #
       # Get detailed information about current user's group

--- a/app/controllers/api/v1/invites_controller.rb
+++ b/app/controllers/api/v1/invites_controller.rb
@@ -9,6 +9,8 @@ module Api
     class InvitesController < ApplicationController
       set_default_serializer InviteSerializer
 
+      denote_title_header 'Invites'
+
       # GET : api/v1/invites
       #
       # Get list of user's invites

--- a/app/controllers/api/v1/passwords_controller.rb
+++ b/app/controllers/api/v1/passwords_controller.rb
@@ -10,6 +10,8 @@ module Api
       required_params! :current_password, :password, :password_confirmation,
                        only: :update, scope: :user
 
+      denote_title_header 'Password'
+
       # PATCH/PUT api/v1/password
       #
       # Update current password with a new one

--- a/app/controllers/api/v1/users/confirmations_controller.rb
+++ b/app/controllers/api/v1/users/confirmations_controller.rb
@@ -15,6 +15,8 @@ module Api
 
         skip_before_action :authorize_access!
 
+        denote_title_header 'Users', 'Confirmation'
+
         # GET : api/v1/users/confirmation/new
         def new
           route_not_found

--- a/app/controllers/api/v1/users/passwords_controller.rb
+++ b/app/controllers/api/v1/users/passwords_controller.rb
@@ -12,7 +12,9 @@ module Api
 
         skip_before_action :authorize_access!
 
-        # GET : api/v1/accounts/password/new
+        denote_title_header 'Users', 'Password'
+
+        # GET : api/v1/users/password/new
         def new
           route_not_found
         end

--- a/app/controllers/api/v1/users/registrations_controller.rb
+++ b/app/controllers/api/v1/users/registrations_controller.rb
@@ -8,9 +8,11 @@ module Api
       #   Used to handle new user registration
       #
       class RegistrationsController < Devise::RegistrationsController
+        skip_before_action :authorize_access!
+
         set_default_serializer UserSerializer
 
-        skip_before_action :authorize_access!
+        denote_title_header 'Users'
 
         %i[cancel new edit update destroy].each do |method|
           define_method(method) { route_not_found }

--- a/app/controllers/api/v1/users/sessions_controller.rb
+++ b/app/controllers/api/v1/users/sessions_controller.rb
@@ -9,10 +9,12 @@ module Api
       #     (SignIn, SignOut)
       #
       class SessionsController < Devise::SessionsController
-        set_default_serializer ::Auth::UserSerializer
-
         skip_before_action :authorize_access!, only: %i[new create]
         skip_before_action :verify_signed_out_user
+
+        set_default_serializer ::Auth::UserSerializer
+
+        denote_title_header 'Users'
 
         # GET :  api/v1/users/sign_in
         def new

--- a/app/controllers/api/v1/users/unlocks_controller.rb
+++ b/app/controllers/api/v1/users/unlocks_controller.rb
@@ -15,6 +15,8 @@ module Api
 
         skip_before_action :authorize_access!
 
+        denote_title_header 'Users', 'Unlock'
+
         # GET :  api/v1/users/unlock/new
         def new
           route_not_found

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -9,6 +9,8 @@ module Api
     class UsersController < ApplicationController
       set_default_serializer UserSerializer
 
+      denote_title_header 'User'
+
       # GET : api/v1/user
       #
       # Get information about current user

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@
 #
 class ApplicationController < ActionController::API
   include Authorizable
+  include Denotable
   include ParamsRequirable
   include Localizable
 
@@ -18,12 +19,13 @@ class ApplicationController < ActionController::API
 
   before_action :destroy_session
   before_action :check_request_format
-  before_action :set_page_title_header
   before_action :set_default_headers
 
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   prepend_before_action :authorize_access!
+
+  denote_title_header 'El Plano'
 
   authorize :user, through: :current_user
   authorize :student, through: :current_student
@@ -65,26 +67,6 @@ class ApplicationController < ActionController::API
       headers['Cache-Control'] = DEFAULT_CACHE_CONTROL
       headers['Pragma'] = 'no-cache' # HTTP 1.0 compatibility
     end
-  end
-
-  def set_page_title_header
-    #
-    # Per https://tools.ietf.org/html/rfc5987, headers need to be ISO-8859-1, not UTF-8
-    #
-    response.headers['Page-Title'] = CGI.escape(page_title('El Plano'))
-  end
-
-  def page_title(*titles)
-    @page_title ||= []
-
-    @page_title.push(*titles.compact) if titles.any?
-
-    if titles.any? && !defined?(@breadcrumb_title)
-      @breadcrumb_title = @page_title.last
-    end
-
-    # Segments are separated by middot
-    @page_title.join(' · ')
   end
 
   def authorize_access!

--- a/app/controllers/concerns/denotable.rb
+++ b/app/controllers/concerns/denotable.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Denotable
+#
+#   Used to add endpoint title annotations in Endpoint-Title header
+#
+module Denotable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    attr_reader :title_segments
+
+    def denote_title_header(*segments)
+      segments.each_with_object(title_segments) { |s, memo| memo << s }
+    end
+
+    def title_segments
+      return @title_segments if already_defined?
+
+      @title_segments = ancestor_defined? ? ancestor_segments : []
+    end
+
+    private
+
+    def already_defined?
+      instance_variable_defined?(:@title_segments)
+    end
+
+    def ancestor_defined?
+      superclass.respond_to?(:title_segments)
+    end
+
+    def ancestor_segments
+      superclass.title_segments.dup
+    end
+  end
+
+  included do
+    append_before_action :set_endpoint_title_header
+
+    def set_endpoint_title_header
+      return if self.class.title_segments.blank?
+
+      #
+      # Segments are separated by middot
+      #
+      title = self.class.title_segments.join(' . ')
+
+      #
+      # Per https://tools.ietf.org/html/rfc5987, headers need to be ISO-8859-1, not UTF-8
+      #
+      response.headers['Endpoint-Title'] = ERB::Util.url_encode(title)
+    end
+  end
+end

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -10,6 +10,8 @@ class UploadsController < ApplicationController
   required_params! :file, :type,
                    only: :create, scope: :upload
 
+  denote_title_header 'Uploads'
+
   # POST : uploads
   #
   # Upload and save file in cache storage

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe ApplicationController do
@@ -52,16 +54,16 @@ describe ApplicationController do
     end
   end
 
-  describe '#set_page_title_header' do
+  describe '#set_endpoint_title_header' do
     let(:controller) { described_class.new }
 
     it 'URI encodes UTF-8 characters in the title' do
       response = double(headers: {})
       allow(controller).to receive(:response).and_return(response)
 
-      controller.send(:set_page_title_header)
+      controller.send(:set_endpoint_title_header)
 
-      expect(response.headers['Page-Title']).to eq('El+Plano')
+      expect(response.headers['Endpoint-Title']).to eq('El%20Plano')
     end
   end
 


### PR DESCRIPTION
Added denotation for each endpoint.
Denotation is used to form `Endpoint-title` that contains breadcrumb-like string in a human-readable format.

`Denotable` is used to provide denotation logic for the controllers