### PR TITLE
Closes #108 Add pagination support

### DIFF
--- a/app/finders/concerns/paginatable.rb
+++ b/app/finders/concerns/paginatable.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# Paginatable
+#
+#   Used to apply paginate filters
+#
+# Arguments :
+#
+#   @params scope [ActiveRecord::Relation]- Scope on which pagination is performed
+#   @params params [Hash] - Pagination filter and sort options
+#
+#     @option params [Integer]  :last_id      - Identity of the last record in previous chunk
+#     @option params [Integer]  :limit        - Quantity of the records in requested chuck
+#     @option params [String]   :direction    - Records sort direction(asc - ascending, desc - descending)
+#     @option params [String]   :field        - Name of the sortable field
+#     @option params [String]   :field_value  - Value of the sortable field
+#
+# @note Any previous sort options will be overwritten with defined in this concern.
+#
+module Paginatable
+  COMPARATORS = { asc: '>', desc: '<' }.freeze
+
+  DEFAULT_DIRECTION = 'desc'
+
+  private_constant :COMPARATORS, :DEFAULT_DIRECTION
+
+  # @param scope [ActiveRecord::Relation]
+  #
+  # @return [ActiveRecord::Relation]
+  #
+  def paginate(scope)
+    scope = filter_by_field(scope)
+    scope = filter_by_last_id(scope)
+
+    scope = limit_items(scope)
+
+    sort(scope)
+  end
+
+  private
+
+  def filter_by_field(items)
+    if params[:field] && params[:field_value]
+      apply_filter(items, params[:field], params[:direction], params[:field_value])
+    else
+      items
+    end
+  end
+
+  def filter_by_last_id(items)
+    return items unless params[:last_id]
+
+    apply_filter(items, 'id', params[:direction], params[:last_id], '')
+  end
+
+  def apply_filter(scope, field, direction, field_value, eq = '=')
+    comparer    = resolve_comparer(direction.to_sym, eq)
+    field_name  = resolve_field_name(field, scope.table_name)
+
+    scope.where("#{field_name} #{comparer} ?", field_value)
+  end
+
+  def resolve_comparer(direction, quality)
+    "#{COMPARATORS[direction]}#{quality}"
+  end
+
+  def resolve_field_name(field, table_name)
+    field.include?('.') ? field : (table_name + ".#{field}")
+  end
+
+  def limit_items(items)
+    items.limit(params[:limit])
+  end
+
+  def sort(items)
+    direction = params.fetch(:direction) { DEFAULT_DIRECTION }
+
+    order_clause = params[:field] ? { params[:field] => direction } : {}
+
+    items.reorder(order_clause.merge(id: direction))
+  end
+end

--- a/doc/api.md
+++ b/doc/api.md
@@ -103,6 +103,48 @@ Localization priority:
 
 User locale --> Request locale --> Default locale
 
+### Collections
+
+Collection resources provide access to information about a list of objects of the same type. 
+For example, you can use a collection resource to access information about a list of events. 
+Collection resources are paged and may be sorted and filtered(depending on availability) - and will always return an list.
+
+<b>NOTE</b> : All collections endpoints available via GET request. 
+
+&nbsp;
+
+#### Filters
+
+Some collections support the ability to filter the results. 
+Filtering a collection resource is conducted via the filters parameter using the following notation:
+
+
+    {
+      "filters": {
+        "search": "search term",
+        "status": "cancelled"
+      }
+    }
+
+<b>NOTE</b> : All filters should be presented in the request's body via JSON object.
+
+&nbsp;
+
+#### Pagination
+
+Pagination uses filters notation and provides the ability to limit records with cursor-like style.
+
+    {
+      "filters": {
+        "last_id": 15,
+        "limit": 10,
+        "direction": "desc",
+        "field_name": "email",
+        "fiend_value": "wat@email.huh"
+      }
+    }
+
+
 ## Authentication
 
 API authentication is based on [OAuth 2.0 specification](https://tools.ietf.org/html/rfc6749)

--- a/spec/finders/concerns/paginate_spec.rb
+++ b/spec/finders/concerns/paginate_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Paginatable do
+  before do
+    class FakeFinder
+      include Paginatable
+
+      attr_reader :params
+
+      def execute(scope, params)
+        @params = params
+
+        paginate(scope)
+      end
+    end
+  end
+
+  after { Object.send :remove_const, :FakeFinder }
+
+  subject { FakeFinder.new.execute(User, params) }
+
+  context 'when last id and direction are set' do
+    let_it_be(:users) { create_list(:user, 3) }
+
+    let(:params) do
+      {
+        limit: nil,
+        field: nil,
+        direction: 'asc',
+        field_value: nil,
+        last_id: users.first.id - 1
+      }
+    end
+
+    it { is_expected.to eq(users) }
+  end
+
+  context 'when field and direction are set' do
+    let_it_be(:last_user)    { create :user, username: 'c' }
+    let_it_be(:first_user)   { create :user, username: 'a' }
+    let_it_be(:middle_user)  { create :user, username: 'b' }
+
+    context 'when direction is ascending' do
+      let(:params) do
+        {
+          limit: 3,
+          field: 'username',
+          direction: 'asc',
+          field_value: nil,
+          last_id: nil
+        }
+      end
+
+      it { is_expected.to eq([first_user, middle_user, last_user]) }
+    end
+
+    context 'when direction is descending' do
+      let(:params) do
+        {
+          limit: 3,
+          field: 'username',
+          direction: 'desc',
+          field_value: nil,
+          last_id: nil
+        }
+      end
+
+      it { is_expected.to eq([last_user, middle_user, first_user]) }
+    end
+  end
+
+  context 'when last value is defined' do
+    let_it_be(:unexpected_user)       { create :user, created_at: 2.days.ago }
+    let_it_be(:first_expected_user)   { create :user, created_at: 1.day.ago }
+    let_it_be(:second_expected_user)  { create :user, created_at: Time.current }
+
+    let(:params) do
+      {
+        limit: 2,
+        field: 'created_at',
+        direction: 'asc',
+        field_value: unexpected_user.created_at.to_s,
+        last_id: unexpected_user.id
+      }
+    end
+
+    it { is_expected.to eq [first_expected_user, second_expected_user] }
+  end
+end


### PR DESCRIPTION
Added concern for finders that allows paginating records in the cursor-like style.
Pagination parameters should be provided via filters parametes.

`Paginatable` is used to include additions in finders to perform pagination.