### PR TITLE
Closes #154 Change accepted values for eventable type parameter

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -106,6 +106,8 @@ class Event < ApplicationRecord
 
   validates :foreground_color, :background_color, allow_nil: true, color: true
 
+  before_validation -> { self.eventable_type = eventable_type&.classify }
+
   def self.filter(filter_name)
     case filter_name.to_s
     when 'group'

--- a/app/services/events/create.rb
+++ b/app/services/events/create.rb
@@ -6,7 +6,7 @@ module Events
   #   Used to create an event
   #
   class Create
-    ALLOWED_TYPES = %w[Student Group].freeze
+    ALLOWED_TYPES = %w[student group].freeze
 
     # see #execute
     def self.call(author, params, &block)
@@ -77,10 +77,12 @@ module Events
       event = author.created_events.build(params)
 
       event.tap do |e|
-        unless ALLOWED_TYPES.include?(e.eventable_type)
-          e.eventable_type = nil
-        end
+        e.eventable_type = nil unless type_allowed?(e.eventable_type)
       end
+    end
+
+    def type_allowed?(type)
+      ALLOWED_TYPES.include?(type)
     end
   end
 end

--- a/spec/acceptance/api/v1/events_spec.rb
+++ b/spec/acceptance/api/v1/events_spec.rb
@@ -99,7 +99,7 @@ resource "User's events" do
       parameter :end_at, 'Event end date', required: true
       parameter :timezone, 'Event timezone', required: true
       parameter :course_id, 'The course identity to which the event is attached'
-      parameter :eventable_type, 'The entity type to which the event is attached(Student, Group)', required: true
+      parameter :eventable_type, 'The entity type to which the event is attached(student, group)', required: true
       parameter :eventable_id, 'The entity identity to which the event is attached', required: true
       parameter :background_color, 'The background color (HEX)'
       parameter :foreground_color, "The foreground color that can be used to write on top of a background with 'background' color (HEX)"
@@ -145,7 +145,7 @@ resource "User's events" do
       parameter :end_at, 'Event end date', required: true
       parameter :timezone, 'Event timezone', required: true
       parameter :course_id, 'The course identity to which the event is attached'
-      parameter :eventable_type, 'The entity type to which the event is attached(Student, Group)', required: true
+      parameter :eventable_type, 'The entity type to which the event is attached(student, group)', required: true
       parameter :eventable_id, 'The entity identity to which the event is attached', required: true
       parameter :background_color, 'The background color (HEX)'
       parameter :foreground_color, "The foreground color that can be used to write on top of a background with 'background' color (HEX)"

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -35,7 +35,7 @@ FactoryBot.define do
           'RRULE:FREQ=DAILY;UNTIL=20150628;INTERVAL=3'
         ],
         eventable_id: create(:student).id,
-        eventable_type: 'Student',
+        eventable_type: 'student',
         background_color: Faker::Color.hex_color,
         foreground_color: Faker::Color.hex_color
       }

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -168,4 +168,42 @@ RSpec.describe Event, type: :model do
       expect(described_class.filter('personal')).to eq([event])
     end
   end
+
+  context 'callbacks' do
+    describe 'before_validation' do
+      before(:each) { model.valid? }
+
+      context 'when eventable type is nil' do
+        let_it_be(:model) { described_class.new(eventable_type: nil) }
+
+        it 'leaves eventable type nil' do
+          expect(model.eventable_type).to be(nil)
+        end
+      end
+
+      context 'when eventable type is a string in downcase' do
+        let_it_be(:model) { described_class.new(eventable_type: 'student') }
+
+        it 'makes eventable type classy like string' do
+          expect(model.eventable_type).to eq('Student')
+        end
+      end
+
+      context 'when eventable type is a string in uppercase' do
+        let_it_be(:model) { described_class.new(eventable_type: 'STUDENT') }
+
+        it 'keeps eventable type as an uppercase string' do
+          expect(model.eventable_type).to eq('STUDENT')
+        end
+      end
+
+      context 'when eventable type is a classy like string' do
+        let_it_be(:model) { described_class.new(eventable_type: 'Student') }
+
+        it 'keeps eventable type as a classy like string' do
+          expect(model.eventable_type).to eq('Student')
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
`api/v1/events` accepts `student` and `group` as an `eventable_type` parameter instead of `Student` and `Group`.
It provides more consistency with JSON:API relationships(`type` field).