### PR TITLE
Fix CVE-2019-16109

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'aws-sdk-s3'
 
 # https://github.com/plataformatec/devise
 # Flexible authentication solution for Rails with Warden.
-gem 'devise', '>= 4.6.1'
+gem 'devise', '>= 4.7.1'
 
 # https://github.com/dry-rb/dry-validation
 # Validation library with type-safe schemas and rules https://dry-rb.org/gems/dry-validation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.3)
-    bcrypt (3.1.12)
+    bcrypt (3.1.13)
     binding_ninja (0.2.2)
     bootsnap (1.3.2)
       msgpack (~> 1.0)
@@ -89,10 +89,10 @@ GEM
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
     database_cleaner (1.7.0)
-    devise (4.6.1)
+    devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0, < 6.0)
+      railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
@@ -267,9 +267,9 @@ GEM
       redis-store (>= 1.2, < 2)
     redis-store (1.6.0)
       redis (>= 2.2, < 5)
-    responders (2.4.1)
-      actionpack (>= 4.2.0, < 6.0)
-      railties (>= 4.2.0, < 6.0)
+    responders (3.0.0)
+      actionpack (>= 5.0)
+      railties (>= 5.0)
     rollbar (2.18.2)
       multi_json
     rspec (3.8.0)
@@ -380,7 +380,7 @@ DEPENDENCIES
   byebug
   connection_pool
   database_cleaner
-  devise (>= 4.6.1)
+  devise (>= 4.7.1)
   doorkeeper (>= 5.0.1)
   dotenv-rails
   dry-validation (>= 1.3.0)


### PR DESCRIPTION
Devise vulnerability

An issue was discovered in Plataformatec Devise before 4.7.1.
It confirms accounts upon receiving a request with a blank confirmation_token,
if a database record has a blank value in the confirmation_token column.

(However, there is no scenario within Devise itself in which such database records would exist.)