### PR TITLE
Fix CVE-2019-18978

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,7 @@ gem 'rack-attack'
 
 # Rack Middleware for handling Cross-Origin Resource Sharing (CORS), which makes cross-origin AJAX possible.
 # https://github.com/cyu/rack-cors
-gem 'rack-cors', require: 'rack/cors'
+gem 'rack-cors', '>= 1.0.6', require: 'rack/cors'
 
 # Exception tracking and logging from Ruby to Rollbar https://docs.rollbar.com/docs/ruby
 # https://github.com/rollbar/rollbar-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,7 +213,8 @@ GEM
     rack (2.0.7)
     rack-attack (6.2.1)
       rack (>= 1.0, < 3)
-    rack-cors (1.0.3)
+    rack-cors (1.0.6)
+      rack (>= 1.6.0)
     rack-protection (2.0.7)
       rack
     rack-test (1.1.0)
@@ -399,7 +400,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rack-attack
-  rack-cors
+  rack-cors (>= 1.0.6)
   rails (~> 5.2.2)
   rails-settings-cached (~> 0.7.2)
   redis


### PR DESCRIPTION
An issue was discovered in the rack-cors (aka Rack CORS Middleware) gem before 1.0.4 for Ruby.
It allows ../ directory traversal to access private resources because resource matching does not ensure that pathnames are in a canonical format.