### PR TITLE
Fix GHSA-7xx3-m584-x994

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'pg', '>= 0.18', '< 2.0'
 
 # Use Puma as the app server
 # https://github.com/puma/puma
-gem 'puma', '~> 3.11'
+gem 'puma', '>= 3.12.2'
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,7 +208,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.1)
-    puma (3.12.1)
+    puma (3.12.2)
     raabro (1.1.6)
     rack (2.0.7)
     rack-attack (6.2.1)
@@ -398,7 +398,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pry-rails
-  puma (~> 3.11)
+  puma (>= 3.12.2)
   rack-attack
   rack-cors (>= 1.0.6)
   rails (~> 5.2.2)


### PR DESCRIPTION
A poorly-behaved client could use keepalive requests to monopolize Puma's reactor and create a denial of service attack.

If more keepalive connections to Puma are opened than there are threads available, additional connections will wait permanently if the attacker sends requests frequently enough.