### PR TITLE
Fix vulnerability CVE-2020-7595

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
     multipart-post (2.1.1)
     mustache (1.1.0)
     nio4r (2.5.2)
-    nokogiri (1.10.4)
+    nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     oauth2 (1.4.2)
       faraday (>= 0.8, < 2.0)


### PR DESCRIPTION
xmlStringLenDecodeEntities in parser.c in libxml2 2.9.10 has an infinite loop in a certain end-of-file situation.
The Nokogiri RubyGem has patched it's vendored copy of libxml2 in order to prevent this issue from affecting nokogiri.