### PR TITLE
Closes #291 Add ability to create self-assigned

### DIFF
--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -7,8 +7,6 @@ module Api
     #   Used to manage authenticated user's(student) tasks
     #
     class TasksController < ApplicationController
-      authorize_with! ::TaskPolicy, only: :create
-
       set_default_serializer ::TaskSerializer
 
       denote_title_header 'Tasks'

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -28,6 +28,18 @@ class Task < ApplicationRecord
             allow_nil: true,
             timeliness: { after: -> { Time.current } }
 
+  validate do
+    errors.add(:students, :invalid_assignment) if assigned? && (!author.group_owner? && !self_assigned?)
+  end
+
+  def self_assigned?
+    student_ids == [author.id]
+  end
+
+  def assigned?
+    student_ids.present?
+  end
+
   def outdated?
     expired_at.nil? ? false : (expired_at < Time.current)
   end

--- a/app/policies/task_policy.rb
+++ b/app/policies/task_policy.rb
@@ -11,21 +11,13 @@ class TaskPolicy < ApplicationPolicy
   #
   alias_rule :update?, :destroy?, to: :manage?
 
-  def create?
-    group_owner?
-  end
-
   def manage?
-    group_owner? && task_author?
+    task_author?
   end
 
   private
 
   def task_author?
     record.author == student
-  end
-
-  def group_owner?
-    student.group_owner?
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,3 +85,15 @@ en:
   uploaders:
     errors:
       too_large: 'is too large (max is %{size} MB)'
+
+  activerecord:
+    errors:
+      models:
+        task:
+          attributes:
+            students:
+              invalid_assignment: 'cannot be selected as performers'
+
+    attributes:
+      task:
+        expired_at: 'Task deadline'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -25,6 +25,11 @@ es:
         restrict_dependent_destroy:
           has_one: No se puede eliminar el registro porque existe un %{record} dependiente
           has_many: No se puede eliminar el registro porque existen %{record} dependientes
+      models:
+        task:
+          attributes:
+            students:
+              invalid_assignment: 'imposible de elegir como intérpretes'
     models:
       event: 'Acontecimiento'
       course: 'Por supuesto'
@@ -37,6 +42,7 @@ es:
       bug_report: 'Informe de error'
       announcement: 'Anuncio'
       label: 'Etiqueta'
+      task: 'Tarea'
     attributes:
       event:
         start_at: 'Empieza en'
@@ -91,6 +97,9 @@ es:
         title: 'Titulo'
         color: 'Color'
         description: 'Descripción'
+      task:
+        students: 'Estudiantes'
+        expired_at: 'Tarea fecha límite'
   date:
     abbr_day_names:
       - dom

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -25,6 +25,11 @@ ru:
         restrict_dependent_destroy:
           has_one: 'Невозможно удалить запись, так как существует зависимость: %{record}'
           has_many: 'Невозможно удалить запись, так как существуют зависимости: %{record}'
+      models:
+        task:
+          attributes:
+            students:
+              invalid_assignment: 'невозможно выбрать в качестве исполнителей'
     models:
       event: 'Мероприятие'
       course: 'Курс'
@@ -37,6 +42,7 @@ ru:
       bug_report: 'Сообщение об ошибке'
       announcement: 'Объявление'
       label: 'Метка'
+      task: 'Задание'
     attributes:
       event:
         start_at: 'Начало'
@@ -91,6 +97,9 @@ ru:
         title: 'Титул'
         color: 'Цвет'
         description: 'Описание'
+      task:
+        students: 'Студенты'
+        expired_at: 'Крайний срок выполнения задания'
   date:
     abbr_day_names:
       - Вс

--- a/spec/acceptance/api/v1/tasks_spec.rb
+++ b/spec/acceptance/api/v1/tasks_spec.rb
@@ -158,7 +158,9 @@ resource "User's event tasks" do
 
         <b>NOTES</b> :
  
-          - This action allowed only for group owner user.
+          - This action allowed for any student, but regular group member can 
+            create only self-assigned tasks for own events(self-assigned events)
+            Group owner(group president) doesn't have such restrictions).
           - Also, includes information about related event and attachments.
       DESC
 
@@ -202,7 +204,7 @@ resource "User's event tasks" do
 
         <b>NOTES</b> :
  
-          - This action allowed only for group owner user.
+          - This action allowed only for authored tasks.
           - Also, includes information about related event and attachments.
       DESC
 
@@ -224,7 +226,7 @@ resource "User's event tasks" do
 
         <b>NOTES</b> :
 
-          - This action allowed only for group owner user.
+          - This action allowed only for authored tasks.
       DESC
 
       do_request

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -36,6 +36,7 @@ FactoryBot.define do
     end
 
     factory :president, traits: [:president]
+    factory :group_supervisor, traits: [:group_supervisor]
   end
 
   factory :student_params, class: Hash do

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :task, class: Task do
     title  { Faker::Lorem.sentence(word_count: 2) }
 
-    author
+    association :author, factory: :group_supervisor
     event
 
     trait :skip_validation do

--- a/spec/policies/task_policy_spec.rb
+++ b/spec/policies/task_policy_spec.rb
@@ -26,20 +26,4 @@ RSpec.describe TaskPolicy do
       it { is_expected.to eq(false) }
     end
   end
-
-  describe '#create?' do
-    subject { policy.apply(:create?) }
-
-    context 'when user is a group owner' do
-      let_it_be(:context) { { student: group_owner, user: group_owner.user } }
-
-      it { is_expected.to eq(true) }
-    end
-
-    context 'when user is a regular group member' do
-      let_it_be(:context) { { student: regular_member, user: regular_member.user } }
-
-      it { is_expected.to eq(false) }
-    end
-  end
 end


### PR DESCRIPTION
Regular group members have the ability to create self-assigned tasks
for self-assigned events(own events)