### PR TITLE
Bump doorkeeper version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem 'device_detector'
 
 # OAuth 2 provider for Ruby on Rails / Grape.
 # https://github.com/doorkeeper-gem/doorkeeper
-gem 'doorkeeper', '~> 5.2.1'
+gem 'doorkeeper', '~> 5.2.5'
 
 # Fishes out the Accept-Language header into an array.
 # https://github.com/iain/http_accept_language

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.3)
     docile (1.3.2)
-    doorkeeper (5.2.1)
+    doorkeeper (5.2.6)
       railties (>= 5)
     dotenv (2.7.5)
     dotenv-rails (2.7.5)
@@ -196,7 +196,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.4.0)
+    loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -388,7 +388,7 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uniform_notifier (1.13.0)
     unparser (0.4.5)
@@ -424,7 +424,7 @@ DEPENDENCIES
   database_cleaner
   device_detector
   devise (>= 4.7.1)
-  doorkeeper (~> 5.2.1)
+  doorkeeper (~> 5.2.5)
   dotenv-rails
   dry-validation (>= 1.3.0)
   factory_bot_rails


### PR DESCRIPTION
Fix GHSA-j7vx-8mqj-cqp9

Information disclosure vulnerability. Allows an attacker to see all Doorkeeper::Application model attribute values (including secrets) using authorized applications controller if it's enabled (GET /oauth/authorized_applications.json).