### PR TITLE
Bump puma version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'pg', '>= 0.18', '< 2.0'
 
 # Use Puma as the app server
 # https://github.com/puma/puma
-gem 'puma', '>= 4.3.3'
+gem 'puma', '>= 4.3.5'
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,7 +240,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.3)
-    puma (4.3.3)
+    puma (4.3.5)
       nio4r (~> 2.0)
     raabro (1.1.6)
     rack (2.2.2)
@@ -439,7 +439,7 @@ DEPENDENCIES
   oj
   pg (>= 0.18, < 2.0)
   pry-rails
-  puma (>= 4.3.3)
+  puma (>= 4.3.5)
   rack-attack
   rack-cors (>= 1.0.6)
   rack-timeout


### PR DESCRIPTION
Fix GHSA-w64w-qqph-5gxm

This is a similar but different vulnerability to the one patched in 3.12.5 and 4.3.4.

A client could smuggle a request through a proxy, causing the proxy to send a response back to another unknown client.

If the proxy uses persistent connections and the client adds another request in via HTTP pipelining, the proxy may mistake it as the first request's body. Puma, however, would see it as two requests, and when processing the second request, send back a response that the proxy does not expect. If the proxy has reused the persistent connection to Puma to send another request for a different client, the second response from the first client will be sent to the second client.

Fix GHSA-x7jg-6pwg-fx5h

By using an invalid transfer-encoding header, an attacker could smuggle an HTTP response.

Originally reported by @ZeddYu, who has our thanks for the detailed report.