### PR TITLE
Bump kaminari version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,7 @@ gem 'shrine', '>= 3.2'
 
 # A Scope & Engine based, clean, powerful, customizable and sophisticated paginator
 # https://github.com/kaminari/kaminari
-gem 'kaminari'
+gem 'kaminari', '>= 1.2.1'
 
 # Settings is a plugin that makes managing a table of global key, value pairs easy.
 # https://github.com/huacnlee/rails-settings-cached

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,18 +179,18 @@ GEM
     jmespath (1.4.0)
     json (2.2.0)
     jwt (2.2.1)
-    kaminari (1.1.1)
+    kaminari (1.2.1)
       activesupport (>= 4.1.0)
-      kaminari-actionview (= 1.1.1)
-      kaminari-activerecord (= 1.1.1)
-      kaminari-core (= 1.1.1)
-    kaminari-actionview (1.1.1)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
       actionview
-      kaminari-core (= 1.1.1)
-    kaminari-activerecord (1.1.1)
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
       activerecord
-      kaminari-core (= 1.1.1)
-    kaminari-core (1.1.1)
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     kramdown (2.1.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -433,7 +433,7 @@ DEPENDENCIES
   fast_jsonapi (>= 1.5)!
   gemoji
   http_accept_language (~> 2.1)
-  kaminari
+  kaminari (>= 1.2.1)
   listen (>= 3.0.5, < 3.2)
   oauth2
   oj


### PR DESCRIPTION
Fix GHSA-r5jw-62xg-j433

There was a vulnerability in versions of Kaminari that would allow an attacker to inject arbitrary code into pages with pagination links.

For example, an attacker could craft pagination links that link to other domain or host:
https://example.com/posts?page=4&original_script_name=https://another-host.example.com

In addition, an attacker could also craft pagination links that include JavaScript code that runs when a user clicks the link:
https://example.com/posts?page=4&original_script_name=javascript:alert(42)%3b//