### PR TITLE
Bump rack version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,7 +246,7 @@ GEM
     puma (4.3.5)
       nio4r (~> 2.0)
     raabro (1.1.6)
-    rack (2.2.2)
+    rack (2.2.3)
     rack-attack (6.2.1)
       rack (>= 1.0, < 3)
     rack-cors (1.0.6)


### PR DESCRIPTION
Fix CVE-2020-8184

A reliance on cookies without validation/integrity check security vulnerability exists in rack < 2.2.3, rack < 2.1.4 that makes it is possible for an attacker to forge a secure or host-only cookie prefix.