### PR TITLE
Bump shrine version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,7 @@ gem 'sidekiq-scheduler'
 
 # File Attachment toolkit for Ruby applications.
 # https://github.com/shrinerb/shrine
-gem 'shrine', '>= 3.2'
+gem 'shrine', '>= 3.3'
 
 # A Scope & Engine based, clean, powerful, customizable and sophisticated paginator
 # https://github.com/kaminari/kaminari

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
       railties (>= 3.2, < 6.1)
-    down (5.1.1)
+    down (5.2.0)
       addressable (~> 2.5)
     dry-configurable (0.11.5)
       concurrent-ruby (~> 1.0)
@@ -243,7 +243,7 @@ GEM
       method_source (~> 0.9.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    public_suffix (4.0.3)
+    public_suffix (4.0.6)
     puma (4.3.5)
       nio4r (~> 2.0)
     raabro (1.1.6)
@@ -369,7 +369,7 @@ GEM
       ruby_http_client (~> 3.3.0)
     shoulda-matchers (4.1.2)
       activesupport (>= 4.2.0)
-    shrine (3.2.1)
+    shrine (3.3.0)
       content_disposition (~> 1.0)
       down (~> 5.1)
     shrine-memory (0.1.0)
@@ -476,7 +476,7 @@ DEPENDENCIES
   rubocop-rspec
   sendgrid-ruby
   shoulda-matchers (>= 4.0.0)
-  shrine (>= 3.2)
+  shrine (>= 3.3)
   shrine-memory
   sidekiq
   sidekiq-scheduler


### PR DESCRIPTION
Fix GHSA-5jjv-x4fq-qjwp

When using the derivation_endpoint plugin, it's possible for the attacker to use a timing attack to guess the signature of the derivation URL.