### PR TITLE
Bump puma from 5.5.1 to 5.6.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,7 +272,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.6)
-    puma (5.5.1)
+    puma (5.6.2)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.5.2)


### PR DESCRIPTION
Fix GHSA-wh98-p28r-vrc9

Prior to puma version 5.6.2, puma may not always call close on the response body. Rails, prior to version 7.0.2.2, depended on the response body being closed in order for its CurrentAttributes implementation to work correctly.

From Rails:

Under certain circumstances response bodies will not be closed, for example a bug in a webserver[1] or a bug in a Rack middleware. In the event a response is not notified of a close, ActionDispatch::Executor will not know to reset thread local state for the next request. This can lead to data being leaked to subsequent requests, especially when interacting with ActiveSupport::CurrentAttributes.

The combination of these two behaviors (Puma not closing the body + Rails' Executor implementation) causes information leakage.